### PR TITLE
Add environment to export notification

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ExportStatusDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ExportStatusDecoder.scala
@@ -10,7 +10,7 @@ import io.circe.parser._
 import io.circe.generic.auto._
 
 object ExportStatusDecoder {
-  case class ExportStatusEvent(consignmentId: UUID, success: Boolean) extends IncomingEvent
+  case class ExportStatusEvent(consignmentId: UUID, success: Boolean, environment: String) extends IncomingEvent
   case class SNS(Message: String)
   case class Record(Sns: SNS)
 

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -99,8 +99,12 @@ object EventMessages {
     }
 
     override def slack(incomingEvent: ExportStatusEvent): Option[SlackMessage] = {
-      val message = s"The export for the consignment ${incomingEvent.consignmentId} has ${if (incomingEvent.success) "completed" else "failed"} for environment ${incomingEvent.environment}"
-      SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", message)))).some
+      if(incomingEvent.environment != "intg" || !incomingEvent.success) {
+        val message = s"The export for the consignment ${incomingEvent.consignmentId} has ${if (incomingEvent.success) "completed" else "failed"} for environment ${incomingEvent.environment}"
+        SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", message)))).some
+      } else {
+        Option.empty
+      }
     }
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -99,7 +99,7 @@ object EventMessages {
     }
 
     override def slack(incomingEvent: ExportStatusEvent): Option[SlackMessage] = {
-      val message = s"The export for the consignment ${incomingEvent.consignmentId} has ${if (incomingEvent.success) "completed" else "failed"}"
+      val message = s"The export for the consignment ${incomingEvent.consignmentId} has ${if (incomingEvent.success) "completed" else "failed"} for environment ${incomingEvent.environment}"
       SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", message)))).some
     }
   }

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaSpecUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaSpecUtils.scala
@@ -29,8 +29,8 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
   val scanEvent5: ScanEvent = ScanEvent(ScanDetail("", List("intg"), ScanFindingCounts(Some(0), Some(0), Some(0), Some(0))))
   val maintenanceResult1: SSMMaintenanceEvent = SSMMaintenanceEvent(true)
   val maintenanceResult2: SSMMaintenanceEvent = SSMMaintenanceEvent(false)
-  val exportStatus1: ExportStatusEvent = ExportStatusEvent(UUID.randomUUID(), true)
-  val exportStatus2: ExportStatusEvent = ExportStatusEvent(UUID.randomUUID(), false)
+  val exportStatus1: ExportStatusEvent = ExportStatusEvent(UUID.randomUUID(), true, "intg")
+  val exportStatus2: ExportStatusEvent = ExportStatusEvent(UUID.randomUUID(), false, "intg")
 
   val events: TableFor3[String, Option[String], Option[String]] =
     Table(
@@ -179,7 +179,7 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
        |    "Records": [
        |        {
        |            "Sns": {
-       |                "Message": "{\\"success\\":${exportStatusEvent.success},\\"consignmentId\\":\\"${exportStatusEvent.consignmentId}\\"}"
+       |                "Message": "{\\"success\\":${exportStatusEvent.success},\\"consignmentId\\":\\"${exportStatusEvent.consignmentId}\\", \\"environment\\": \\"${exportStatusEvent.environment}\\"}"
        |            }
        |        }
        |    ]
@@ -206,7 +206,7 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
        |    "type" : "section",
        |    "text" : {
        |      "type" : "mrkdwn",
-       |      "text" : "The export for the consignment ${exportStatusEvent.consignmentId} has ${if (exportStatusEvent.success) "completed" else "failed"}"
+       |      "text" : "The export for the consignment ${exportStatusEvent.consignmentId} has ${if (exportStatusEvent.success) "completed" else "failed"} for environment ${exportStatusEvent.environment}"
        |    }
        |  } ]
        |}""".stripMargin

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaSpecUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaSpecUtils.scala
@@ -31,6 +31,8 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
   val maintenanceResult2: SSMMaintenanceEvent = SSMMaintenanceEvent(false)
   val exportStatus1: ExportStatusEvent = ExportStatusEvent(UUID.randomUUID(), true, "intg")
   val exportStatus2: ExportStatusEvent = ExportStatusEvent(UUID.randomUUID(), false, "intg")
+  val exportStatus3: ExportStatusEvent = ExportStatusEvent(UUID.randomUUID(), true, "staging")
+  val exportStatus4: ExportStatusEvent = ExportStatusEvent(UUID.randomUUID(), false, "staging")
 
   val events: TableFor3[String, Option[String], Option[String]] =
     Table(
@@ -42,8 +44,10 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
       (scanEventInputText(scanEvent5), None, None),
       (maintenanceEventInputText(maintenanceResult1), None, None),
       (maintenanceEventInputText(maintenanceResult2), None, Some(maintenanceEventBodyJson)),
-      (exportStatusEventInputText(exportStatus1), None, Some(exportStatusSlackBody(exportStatus1))),
+      (exportStatusEventInputText(exportStatus1), None, None),
       (exportStatusEventInputText(exportStatus2), None, Some(exportStatusSlackBody(exportStatus2))),
+      (exportStatusEventInputText(exportStatus3), None, Some(exportStatusSlackBody(exportStatus3))),
+      (exportStatusEventInputText(exportStatus4), None, Some(exportStatusSlackBody(exportStatus4))),
     )
 
   val wiremockSesEndpoint = new WireMockServer(9001)


### PR DESCRIPTION
- Add environment to incoming json object and use it.
- Update tests to work with new slack message
- Also don't bother sending alerts for successful exports on integration because it's very spammy.