### PR TITLE
Add a description to all tests

### DIFF
--- a/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
@@ -1,17 +1,17 @@
 package uk.gov.nationalarchives.notifications
 
-import org.scalatest.prop.TableFor3
+import org.scalatest.prop.TableFor4
 import uk.gov.nationalarchives.notifications.EcrScanIntegrationSpec.{getCounts, scanEventInputText}
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.{ScanDetail, ScanEvent, ScanFindingCounts}
 
 class EcrScanIntegrationSpec extends LambdaIntegrationSpec {
-  override lazy val events: TableFor3[String, Option[String], Option[String]] = Table(
-    ("input", "emailBody", "slackBody"),
-    (scanEventInputText(scanEvent1), Some(expectedEmailBody(scanEvent1)), Some(expectedSlackBody(scanEvent1))),
-    (scanEventInputText(scanEvent2), Some(expectedEmailBody(scanEvent2)), Some(expectedSlackBody(scanEvent2))),
-    (scanEventInputText(scanEvent3), None, None),
-    (scanEventInputText(scanEvent4), None, None),
-    (scanEventInputText(scanEvent5), None, None)
+  override lazy val events: TableFor4[String, String, Option[String], Option[String]] = Table(
+    ("description", "input", "emailBody", "slackBody"),
+    ("an ECR scan of 'latest' with a mix of severities", scanEventInputText(scanEvent1), Some(expectedEmailBody(scanEvent1)), Some(expectedSlackBody(scanEvent1))),
+    ("an ECR scan of 'latest' with only low severity vulnerabilities", scanEventInputText(scanEvent2), Some(expectedEmailBody(scanEvent2)), Some(expectedSlackBody(scanEvent2))),
+    ("an ECR scan of 'latest' with no results", scanEventInputText(scanEvent3), None, None),
+    ("an ECR scan of an image with a non-deployment tag", scanEventInputText(scanEvent4), None, None),
+    ("an ECR scan of 'intg' with no results", scanEventInputText(scanEvent5), None, None)
   )
 
   private lazy val scanEvent1: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(Some(10), Some(100), Some(1000), Some(10000))))

--- a/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
@@ -2,18 +2,18 @@ package uk.gov.nationalarchives.notifications
 
 import java.util.UUID
 
-import org.scalatest.prop.TableFor3
+import org.scalatest.prop.TableFor4
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.{ExportStatusEvent, ExportSuccessDetails}
 
 class ExportIntegrationSpec extends LambdaIntegrationSpec {
-  override lazy val events: TableFor3[String, Option[String], Option[String]] = Table(
-    ("input", "emailBody", "slackBody"),
-    (exportStatusEventInputText(exportStatus1), None, None),
-    (exportStatusEventInputText(exportStatus2), None, Some(expectedSlackMessage(exportStatus2))),
-    (exportStatusEventInputText(exportStatus3), None, Some(expectedSlackMessage(exportStatus3))),
-    (exportStatusEventInputText(exportStatus4), None, Some(expectedSlackMessage(exportStatus4))),
-    (exportStatusEventInputText(exportStatus5), None, Some(expectedSlackMessage(exportStatus5))),
-    (exportStatusEventInputText(exportStatus6), None, Some(expectedSlackMessage(exportStatus6))),
+  override lazy val events: TableFor4[String, String, Option[String], Option[String]] = Table(
+    ("description", "input", "emailBody", "slackBody"),
+    ("a successful export event on intg", exportStatusEventInputText(exportStatus1), None, None),
+    ("a failed export event on intg", exportStatusEventInputText(exportStatus2), None, Some(expectedSlackMessage(exportStatus2))),
+    ("a successful export event on staging", exportStatusEventInputText(exportStatus3), None, Some(expectedSlackMessage(exportStatus3))),
+    ("a failed export event on staging", exportStatusEventInputText(exportStatus4), None, Some(expectedSlackMessage(exportStatus4))),
+    ("a failed export on intg with no error details", exportStatusEventInputText(exportStatus5), None, Some(expectedSlackMessage(exportStatus5))),
+    ("a failed export on staging with no error details", exportStatusEventInputText(exportStatus6), None, Some(expectedSlackMessage(exportStatus6))),
   )
 
   private lazy val successDetails = ExportSuccessDetails(UUID.randomUUID(), "consignmentRef1", "tb-body1")

--- a/src/test/scala/uk/gov/nationalarchives/notifications/JenkinsBackupIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/JenkinsBackupIntegrationSpec.scala
@@ -1,14 +1,14 @@
 package uk.gov.nationalarchives.notifications
 
-import org.scalatest.prop.TableFor3
+import org.scalatest.prop.TableFor4
 import uk.gov.nationalarchives.notifications.decoders.SSMMaintenanceDecoder.SSMMaintenanceEvent
 
 class JenkinsBackupIntegrationSpec extends LambdaIntegrationSpec {
 
-  override lazy val events: TableFor3[String, Option[String], Option[String]] = Table(
-    ("input", "emailBody", "slackBody"),
-    (maintenanceEventInputText(maintenanceResult1), None, None),
-    (maintenanceEventInputText(maintenanceResult2), None, Some(expectedBackupFailureSlackMessage))
+  override lazy val events: TableFor4[String, String, Option[String], Option[String]] = Table(
+    ("description", "input", "emailBody", "slackBody"),
+    ("a successful Jenkins backup event", maintenanceEventInputText(maintenanceResult1), None, None),
+    ("a failed Jenkins backup event", maintenanceEventInputText(maintenanceResult2), None, Some(expectedBackupFailureSlackMessage))
   )
 
   private lazy val maintenanceResult1: SSMMaintenanceEvent = SSMMaintenanceEvent(true)

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaIntegrationSpec.scala
@@ -1,16 +1,16 @@
 package uk.gov.nationalarchives.notifications
 
 import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, postRequestedFor, urlEqualTo}
-import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3}
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor4}
 
 trait LambdaIntegrationSpec extends LambdaSpecUtils with TableDrivenPropertyChecks {
-  def events: TableFor3[String, Option[String], Option[String]]
+  def events: TableFor4[String, String, Option[String], Option[String]]
 
   forAll(events) {
-    (input, emailBody, slackBody) => {
+    (description, input, emailBody, slackBody) => {
       emailBody match {
         case Some(body) =>
-          "the process method" should s"send an email message for event $input" in {
+          "the process method" should s"send an email message for $description" in {
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
             wiremockSesEndpoint.verify(1,
@@ -19,7 +19,7 @@ trait LambdaIntegrationSpec extends LambdaSpecUtils with TableDrivenPropertyChec
             )
           }
         case None =>
-          "the process method" should s"not send an email message for event $input" in {
+          "the process method" should s"not send an email message for $description" in {
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
             wiremockSesEndpoint.verify(0, postRequestedFor(urlEqualTo("/")))
@@ -28,7 +28,7 @@ trait LambdaIntegrationSpec extends LambdaSpecUtils with TableDrivenPropertyChec
 
       slackBody match {
         case Some(body) =>
-          "the process method" should s"send a slack message for event $input" in {
+          "the process method" should s"send a slack message for $description" in {
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
             wiremockSlackServer.verify(slackBody.size,
@@ -37,7 +37,7 @@ trait LambdaIntegrationSpec extends LambdaSpecUtils with TableDrivenPropertyChec
             )
           }
         case None =>
-          "the process method" should s"not send a slack message for event $input" in {
+          "the process method" should s"not send a slack message for $description" in {
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
             wiremockSlackServer.verify(0,


### PR DESCRIPTION
This makes the tests names clearer. For example:

```
should not send a Slack message for an ECR scan of 'intg' with no results
```

rather than:

```
should not send a slack message for event
{
  "detail": {
    "scan-status": "COMPLETE",
    "repository-name": "yara-dependencies",
    "image-tags" : ["intg"],
    "finding-severity-counts": {
      "CRITICAL": 0,
      "HIGH": 0,
      "MEDIUM": 0,
      "LOW": 0
    }
  }
}
```

The second name is even harder to read in IntelliJ, because it only shows you the first line in the test panel.

This is particularly useful when a test fails, because IntelliJ can't navigate to the source of a parameterized test, so you couldn't work out which test case failed without interpreting the event yourself.