### PR TITLE
Filter vulnerabilities using scan findings report

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val sttpCatsEffect = "com.softwaremill.sttp.client" %% "async-http-client-backend-cats" % "2.2.9"
   lazy val typesafe = "com.typesafe" % "config" % "1.4.0"
   lazy val scalaTags = "com.lihaoyi" %% "scalatags" % "0.8.2"
-  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.4"
+  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.14"
   lazy val loggerSlf4j = "org.typelevel" %% "log4cats-slf4j" % "1.2.0-RC2"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.2"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "2.27.2"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,3 +9,13 @@ ses {
     to = ${TO_EMAIL}
   }
 }
+ecr {
+  endpoint = "https://ecr.eu-west-2.amazonaws.com"
+}
+alerts {
+  ecr-scan {
+    mute: ""
+    // If provided, this should be a comma-separated string, e.g. "CVE-1,CVE-2,RHSA-3"
+    mute: ${?MUTED_VULNERABILITIES}
+  }
+}

--- a/src/main/scala/uk/gov/nationalarchives/notifications/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/LambdaRunner.scala
@@ -11,8 +11,9 @@ object LambdaRunner extends App {
        |{
        |  "detail": {
        |    "scan-status": "COMPLETE",
-       |    "repository-name": "yara-dependencies",
+       |    "repository-name": "yara",
        |    "image-tags" : ["intg"],
+       |    "image-digest": "sha256:401d492b2ab0d6639a3889cafae28188666c1ebd827d86e0ce67819211a0c062",
        |    "finding-severity-counts": {
        |      "CRITICAL": 0,
        |      "HIGH": 0,

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ScanDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ScanDecoder.scala
@@ -8,10 +8,8 @@ object ScanDecoder {
 
   case class ScanDetail(repositoryName: String, tags: List[String], findingSeverityCounts: ScanFindingCounts)
 
-  case class ScanFindingCounts(critical: Option[Int], high: Option[Int], medium: Option[Int], low: Option[Int]) {
-    def areAllZero(): Boolean = {
-      (critical.getOrElse(0) + high.getOrElse(0) + medium.getOrElse(0) + low.getOrElse(0)) == 0
-    }
+  case class ScanFindingCounts(critical: Int, high: Int, medium: Int, low: Int) {
+    def areAllZero(): Boolean = (critical + high + medium + low) == 0
   }
 
   implicit val decodeScanFindingCounts: Decoder[ScanFindingCounts] = (c: HCursor) => for {
@@ -19,7 +17,7 @@ object ScanDecoder {
     high <- c.downField("HIGH").as[Option[Int]]
     medium <- c.downField("MEDIUM").as[Option[Int]]
     low <- c.downField("LOW").as[Option[Int]]
-  } yield ScanFindingCounts(critical, high, medium, low)
+  } yield ScanFindingCounts(critical.getOrElse(0), high.getOrElse(0), medium.getOrElse(0), low.getOrElse(0))
 
   implicit val decodeScanDetail: Decoder[ScanDetail] = (c: HCursor) => for {
     repositoryName <- c.downField("repository-name").as[String]

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ScanDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ScanDecoder.scala
@@ -13,14 +13,23 @@ object ScanDecoder {
                          findingSeverityCounts: ScanFindingCounts
                        )
 
-  case class ScanFindingCounts(critical: Int, high: Int, medium: Int, low: Int)
+  case class ScanFindingCounts(critical: Int, high: Int, medium: Int, low: Int, informational: Int, undefined: Int)
 
   implicit val decodeScanFindingCounts: Decoder[ScanFindingCounts] = (c: HCursor) => for {
     critical <- c.downField("CRITICAL").as[Option[Int]]
     high <- c.downField("HIGH").as[Option[Int]]
     medium <- c.downField("MEDIUM").as[Option[Int]]
     low <- c.downField("LOW").as[Option[Int]]
-  } yield ScanFindingCounts(critical.getOrElse(0), high.getOrElse(0), medium.getOrElse(0), low.getOrElse(0))
+    informational <- c.downField("INFORMATIONAL").as[Option[Int]]
+    undefined <- c.downField("UNDEFINED").as[Option[Int]]
+  } yield ScanFindingCounts(
+    critical.getOrElse(0),
+    high.getOrElse(0),
+    medium.getOrElse(0),
+    low.getOrElse(0),
+    informational.getOrElse(0),
+    undefined.getOrElse(0)
+  )
 
   implicit val decodeScanDetail: Decoder[ScanDetail] = (c: HCursor) => for {
     repositoryName <- c.downField("repository-name").as[String]

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ScanDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ScanDecoder.scala
@@ -6,11 +6,14 @@ object ScanDecoder {
 
   case class ScanEvent(detail: ScanDetail) extends IncomingEvent
 
-  case class ScanDetail(repositoryName: String, tags: List[String], findingSeverityCounts: ScanFindingCounts)
+  case class ScanDetail(
+                         repositoryName: String,
+                         tags: List[String],
+                         imageDigest: String,
+                         findingSeverityCounts: ScanFindingCounts
+                       )
 
-  case class ScanFindingCounts(critical: Int, high: Int, medium: Int, low: Int) {
-    def areAllZero(): Boolean = (critical + high + medium + low) == 0
-  }
+  case class ScanFindingCounts(critical: Int, high: Int, medium: Int, low: Int)
 
   implicit val decodeScanFindingCounts: Decoder[ScanFindingCounts] = (c: HCursor) => for {
     critical <- c.downField("CRITICAL").as[Option[Int]]
@@ -22,8 +25,9 @@ object ScanDecoder {
   implicit val decodeScanDetail: Decoder[ScanDetail] = (c: HCursor) => for {
     repositoryName <- c.downField("repository-name").as[String]
     imageTags <- c.downField("image-tags").as[List[String]]
+    imageDigest <- c.downField("image-digest").as[String]
     findingSeverityCounts <- c.downField("finding-severity-counts").as[ScanFindingCounts]
-  } yield ScanDetail(repositoryName, imageTags, findingSeverityCounts)
+  } yield ScanDetail(repositoryName, imageTags, imageDigest, findingSeverityCounts)
 
   val decodeScanEvent: Decoder[IncomingEvent] = (c: HCursor) => for {
     detail <- c.downField("detail").as[ScanDetail]

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -27,7 +27,7 @@ object EventMessages {
 
     private def slackBlock(text: String) = SlackBlock("section", SlackText("mrkdwn", text))
 
-    private def countBlock(count: Option[Int], level: String) = slackBlock(s"${count.getOrElse(0)} $level severity vulnerabilities")
+    private def countBlock(count: Int, level: String) = slackBlock(s"$count $level severity vulnerabilities")
 
     private def allowedTagMatches(detail: ScanDetail): Set[String] = detail.tags.toSet.intersect(allowedTags)
 
@@ -53,10 +53,10 @@ object EventMessages {
     override def email(event: ScanEvent): Option[SESUtils.Email] = {
       val detail = event.detail
       if(shouldSendNotification(detail)) {
-        val critical = detail.findingSeverityCounts.critical.getOrElse(0)
-        val high = detail.findingSeverityCounts.high.getOrElse(0)
-        val medium = detail.findingSeverityCounts.medium.getOrElse(0)
-        val low = detail.findingSeverityCounts.low.getOrElse(0)
+        val critical = detail.findingSeverityCounts.critical
+        val high = detail.findingSeverityCounts.high
+        val medium = detail.findingSeverityCounts.medium
+        val low = detail.findingSeverityCounts.low
 
         val message = html(
           body(

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -1,16 +1,21 @@
 package uk.gov.nationalarchives.notifications.messages
 
+import java.net.URI
+
 import cats.effect.IO
 import cats.implicits._
 import com.typesafe.config.ConfigFactory
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scalatags.Text.all._
-import uk.gov.nationalarchives.aws.utils.SESUtils
+import software.amazon.awssdk.services.ecr.model.FindingSeverity
 import uk.gov.nationalarchives.aws.utils.SESUtils.Email
+import uk.gov.nationalarchives.aws.utils.{Clients, ECRUtils, SESUtils}
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportStatusEvent
 import uk.gov.nationalarchives.notifications.decoders.SSMMaintenanceDecoder.SSMMaintenanceEvent
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.{ScanDetail, ScanEvent}
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 object EventMessages {
 
@@ -22,31 +27,55 @@ object EventMessages {
 
   case class SlackMessage(blocks: List[SlackBlock])
 
-  implicit val scanEventMessages: Messages[ScanEvent] = new Messages[ScanEvent] {
+  implicit val scanEventMessages: Messages[ScanEvent, ImageScanReport] = new Messages[ScanEvent, ImageScanReport] {
 
     // Tags that we are interested in because they are set on deployed images. We can ignore other tags (e.g. version
     // tags) because they represent old images or ones which have not been deployed yet.
     private val releaseTags = Set("latest", "intg", "staging", "prod", "mgmt")
 
-    private def slackBlock(text: String) = SlackBlock("section", SlackText("mrkdwn", text))
+    private val config = ConfigFactory.load
 
-    private def countBlock(count: Int, level: String) = slackBlock(s"$count $level severity vulnerabilities")
+    private val mutedVulnerabilities: Set[String] = config.getString("alerts.ecr-scan.mute")
+      .split(",")
+      .toSet
+
+    private def slackBlock(text: String) = SlackBlock("section", SlackText("mrkdwn", text))
 
     private def includesReleaseTags(imageTags: List[String]): Boolean =
       imageTags.toSet.intersect(releaseTags).nonEmpty
 
-    private def shouldSendNotification(detail: ScanDetail): Boolean =
-      includesReleaseTags(detail.tags) && !detail.findingSeverityCounts.areAllZero()
+    private def shouldSendNotification(detail: ScanDetail, findings: Seq[Finding]): Boolean =
+      includesReleaseTags(detail.tags) && findings.nonEmpty
 
-    override def slack(event: ScanEvent): Option[SlackMessage] = {
+    private def filterReport(report: ImageScanReport): ImageScanReport = {
+      val filteredFindings = report.findings.filterNot(finding => mutedVulnerabilities.contains(finding.name))
+      report.copy(findings = filteredFindings)
+    }
+
+    override def context(event: ScanEvent): IO[ImageScanReport] = {
+      val repoName = event.detail.repositoryName
+      val ecrClient = Clients.ecr(URI.create(config.getString("ecr.endpoint")))
+      val ecrUtils: ECRUtils = ECRUtils(ecrClient)
+      val findingsResponse = ecrUtils.imageScanFindings(repoName, event.detail.imageDigest)
+
+      findingsResponse.map(response => {
+        val findings = response.imageScanFindings.findings.asScala.map(finding => {
+          Finding(finding.name, finding.severity)
+        }).toSeq
+        ImageScanReport(findings)
+      })
+    }
+
+    override def slack(event: ScanEvent, report: ImageScanReport): Option[SlackMessage] = {
       val detail = event.detail
-      if(shouldSendNotification(detail)) {
+      val filteredReport = filterReport(report)
+      if (shouldSendNotification(detail, filteredReport.findings)) {
         val headerBlock = slackBlock(s"*ECR image scan complete on image ${detail.repositoryName} ${detail.tags.mkString(",")}*")
-        val severityCounts = detail.findingSeverityCounts
-        val criticalBlock = countBlock(severityCounts.critical, "critical")
-        val highBlock = countBlock(severityCounts.high, "high")
-        val mediumBlock = countBlock(severityCounts.medium, "medium")
-        val lowBlock = countBlock(severityCounts.low, "low")
+
+        val criticalBlock = slackBlock(s"${filteredReport.criticalCount} critical severity vulnerabilities")
+        val highBlock = slackBlock(s"${filteredReport.highCount} high severity vulnerabilities")
+        val mediumBlock = slackBlock(s"${filteredReport.mediumCount} medium severity vulnerabilities")
+        val lowBlock = slackBlock(s"${filteredReport.lowCount} low severity vulnerabilities")
         val documentationBlock = slackBlock("See the TDR developer manual for guidance on fixing these vulnerabilities: " +
           "https://github.com/nationalarchives/tdr-dev-documentation/blob/master/manual/alerts/ecr-scans.md")
         SlackMessage(List(headerBlock, criticalBlock, highBlock, mediumBlock, lowBlock, documentationBlock)).some
@@ -55,22 +84,18 @@ object EventMessages {
       }
     }
 
-    override def email(event: ScanEvent): Option[SESUtils.Email] = {
+    override def email(event: ScanEvent, report: ImageScanReport): Option[SESUtils.Email] = {
       val detail = event.detail
-      if(shouldSendNotification(detail)) {
-        val critical = detail.findingSeverityCounts.critical
-        val high = detail.findingSeverityCounts.high
-        val medium = detail.findingSeverityCounts.medium
-        val low = detail.findingSeverityCounts.low
-
+      val filteredReport = filterReport(report)
+      if (shouldSendNotification(detail, filteredReport.findings)) {
         val message = html(
           body(
             h1(s"Image scan results for ${detail.repositoryName}"),
             div(
-              p(s"$critical critical vulnerabilities"),
-              p(s"$high high vulnerabilities"),
-              p(s"$medium medium vulnerabilities"),
-              p(s"$low low vulnerabilities")
+              p(s"${filteredReport.criticalCount} critical vulnerabilities"),
+              p(s"${filteredReport.highCount} high vulnerabilities"),
+              p(s"${filteredReport.mediumCount} medium vulnerabilities"),
+              p(s"${filteredReport.lowCount} low vulnerabilities")
             ),
             div(
               p("See the TDR developer manual for guidance on fixing these vulnerabilities: " +
@@ -85,10 +110,12 @@ object EventMessages {
     }
   }
 
-  implicit val maintenanceEventMessages: Messages[SSMMaintenanceEvent] = new Messages[SSMMaintenanceEvent] {
-    override def email(scanDetail: SSMMaintenanceEvent): Option[Email] = Option.empty
+  implicit val maintenanceEventMessages: Messages[SSMMaintenanceEvent, Unit] = new Messages[SSMMaintenanceEvent, Unit] {
+    override def context(event: SSMMaintenanceEvent): IO[Unit] = IO.unit
 
-    override def slack(scanDetail: SSMMaintenanceEvent): Option[SlackMessage] = {
+    override def email(scanDetail: SSMMaintenanceEvent, context: Unit): Option[Email] = Option.empty
+
+    override def slack(scanDetail: SSMMaintenanceEvent, context: Unit): Option[SlackMessage] = {
       if (scanDetail.success) {
         None
       } else {
@@ -97,13 +124,15 @@ object EventMessages {
     }
   }
 
-  implicit val exportStatusEventMessages: Messages[ExportStatusEvent] = new Messages[ExportStatusEvent] {
-    override def email(incomingEvent: ExportStatusEvent): Option[Email] = {
+  implicit val exportStatusEventMessages: Messages[ExportStatusEvent, Unit] = new Messages[ExportStatusEvent, Unit] {
+    override def context(event: ExportStatusEvent): IO[Unit] = IO.unit
+
+    override def email(incomingEvent: ExportStatusEvent, context: Unit): Option[Email] = {
       logger.info(s"Skipping email for export complete message for consignment ${incomingEvent.consignmentId}")
       Option.empty
     }
 
-    override def slack(incomingEvent: ExportStatusEvent): Option[SlackMessage] = {
+    override def slack(incomingEvent: ExportStatusEvent, context: Unit): Option[SlackMessage] = {
       if(incomingEvent.environment != "intg" || !incomingEvent.success) {
 
         val exportInfoMessage = constructExportInfoMessage(incomingEvent)
@@ -129,3 +158,12 @@ object EventMessages {
     }
   }
 }
+
+case class ImageScanReport(findings: Seq[Finding]) {
+  def criticalCount: Int = findings.count(_.severity == FindingSeverity.CRITICAL)
+  def highCount: Int = findings.count(_.severity == FindingSeverity.HIGH)
+  def mediumCount: Int = findings.count(_.severity == FindingSeverity.MEDIUM)
+  def lowCount: Int = findings.count(_.severity == FindingSeverity.LOW)
+}
+
+case class Finding(name: String, severity: FindingSeverity)

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -9,3 +9,12 @@ ses {
       to = "aws_tdr_management@nationalarchives.gov.uk"
   }
 }
+ecr {
+  endpoint = "http://localhost:9003"
+}
+alerts {
+  ecr-scan {
+    // Fake CVE numbers with the right format
+    mute: "CVE-2016-12345678,CVE-2020-98765"
+  }
+}

--- a/src/test/resources/ecr-findings/including-muted-vulnerability.json
+++ b/src/test/resources/ecr-findings/including-muted-vulnerability.json
@@ -3,7 +3,7 @@
     "findings": [
       {
         "name": "RHSA-2020:4952",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "CRITICAL",
         "attributes": [
@@ -19,7 +19,7 @@
       },
       {
         "name": "RHSA-2020:5476",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "HIGH",
         "attributes": [
@@ -35,7 +35,7 @@
       },
       {
         "name": "RHSA-2020:5476",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "HIGH",
         "attributes": [
@@ -51,7 +51,7 @@
       },
       {
         "name": "RHSA-2020:4599",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -67,7 +67,7 @@
       },
       {
         "name": "RHSA-2020:4497",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -83,7 +83,7 @@
       },
       {
         "name": "RHSA-2020:4484",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -99,7 +99,7 @@
       },
       {
         "name": "RHSA-2020:4444",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -115,7 +115,7 @@
       },
       {
         "name": "RHSA-2020:4444",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -131,7 +131,7 @@
       },
       {
         "name": "RHSA-2020:4444",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -147,7 +147,7 @@
       },
       {
         "name": "RHSA-2020:4444",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -163,7 +163,7 @@
       },
       {
         "name": "RHSA-2020:4490",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -179,7 +179,7 @@
       },
       {
         "name": "RHSA-2020:5483",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -195,7 +195,7 @@
       },
       {
         "name": "RHSA-2020:4305",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -211,7 +211,7 @@
       },
       {
         "name": "RHSA-2020:4443",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -227,7 +227,7 @@
       },
       {
         "name": "RHSA-2020:4599",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -243,7 +243,7 @@
       },
       {
         "name": "RHSA-2020:4482",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -259,7 +259,7 @@
       },
       {
         "name": "RHSA-2020:4508",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -275,7 +275,7 @@
       },
       {
         "name": "RHSA-2020:4545",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -291,7 +291,7 @@
       },
       {
         "name": "RHSA-2020:4545",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -307,7 +307,7 @@
       },
       {
         "name": "RHSA-2020:4479",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -323,7 +323,7 @@
       },
       {
         "name": "RHSA-2020:4539",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -339,7 +339,7 @@
       },
       {
         "name": "RHSA-2020:4433",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -355,7 +355,7 @@
       },
       {
         "name": "RHSA-2020:4432",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -371,7 +371,7 @@
       },
       {
         "name": "RHSA-2020:4433",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -387,7 +387,7 @@
       },
       {
         "name": "RHSA-2020:4432",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -403,7 +403,7 @@
       },
       {
         "name": "RHSA-2020:4432",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -419,7 +419,7 @@
       },
       {
         "name": "RHSA-2020:4442",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -435,7 +435,7 @@
       },
       {
         "name": "RHSA-2020:4469",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "LOW",
         "attributes": [
@@ -451,7 +451,7 @@
       },
       {
         "name": "RHSA-2020:4514",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "LOW",
         "attributes": [
@@ -467,7 +467,7 @@
       },
       {
         "name": "RHSA-2020:4514",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "LOW",
         "attributes": [
@@ -484,7 +484,7 @@
       {
         "name": "CVE-2016-12345678",
         "uri": "https://example.com",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "severity": "LOW",
         "attributes": [
           {

--- a/src/test/resources/ecr-findings/including-muted-vulnerability.json
+++ b/src/test/resources/ecr-findings/including-muted-vulnerability.json
@@ -1,0 +1,519 @@
+{
+  "imageScanFindings": {
+    "findings": [
+      {
+        "name": "RHSA-2020:4952",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "CRITICAL",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.9.1-4.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "freetype"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:5476",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "HIGH",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:1.1.1c-15.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "openssl"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:5476",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "HIGH",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:1.1.1c-15.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "openssl-libs"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4599",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "7.61.1-12.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "curl"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4497",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.1.27-1.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "cyrus-sasl-lib"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4484",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.2.5-3.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "expat"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4444",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.28-101.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "glibc"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4444",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.28-101.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "glibc-common"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4444",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.28-101.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "glibc-langpack-en"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4444",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.28-101.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "glibc-minimal-langpack"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4490",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.2.9-1.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "gnupg2"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:5483",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.6.8-11.el8_2"
+          },
+          {
+            "key": "package_name",
+            "value": "gnutls"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4305",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:11.0.8.10-0.el8_2"
+          },
+          {
+            "key": "package_name",
+            "value": "java-11-openjdk-headless"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4443",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.3.2-8.el8_1"
+          },
+          {
+            "key": "package_name",
+            "value": "libarchive"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4599",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "7.61.1-12.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libcurl"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4482",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1.8.3-4.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libgcrypt"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4508",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "0.7.7-1.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libsolv"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4545",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "0.9.0-4.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libssh"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4545",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "0.9.0-4.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libssh-config"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4479",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.9.7-7.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libxml2"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4539",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "10.32-1.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "pcre2"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4433",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.6.8-23.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "platform-python"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4432",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "9.0.3-16.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "platform-python-pip"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4433",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.6.8-23.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "python3-libs"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4432",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "9.0.3-16.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "python3-pip"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4432",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "9.0.3-16.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "python3-pip-wheel"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4442",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.26.0-6.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "sqlite-libs"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4469",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:2.2.6-33.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "cups-libs"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4514",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:1.1.1c-15.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "openssl"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4514",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:1.1.1c-15.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "openssl-libs"
+          }
+        ]
+      },
+      {
+        "name": "CVE-2016-12345678",
+        "uri": "https://example.com",
+        "description": "Some vulnerability description"
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "239-31.el8_2.2"
+          },
+          {
+            "key": "package_name",
+            "value": "systemd-libs"
+          }
+        ]
+      }
+    ],
+    "imageScanCompletedAt": 1615279785,
+    "vulnerabilitySourceUpdatedAt": 1615203847,
+    "findingSeverityCounts": {
+      "MEDIUM": 24,
+      "LOW": 4,
+      "HIGH": 3
+    }
+  },
+  "registryId": "1234",
+  "repositoryName": "some-repo-name",
+  "imageId": {
+    "imageDigest": "sha256:ca236bc619f5513544fbae8873a58a46485742428934de7483d16f60ce052b4b",
+    "imageTag": "intg"
+  },
+  "imageScanStatus": {
+    "status": "COMPLETE",
+    "description": "The scan was completed successfully."
+  }
+}

--- a/src/test/resources/ecr-findings/informational.json
+++ b/src/test/resources/ecr-findings/informational.json
@@ -1,0 +1,27 @@
+{
+  "imageScanFindings": {
+    "findings": [
+      {
+        "name": "CVE-2020-123456789",
+        "uri": "https://example.com/CVE-2020-123456789",
+        "severity": "INFORMATIONAL",
+        "attributes": []
+      }
+    ],
+    "imageScanCompletedAt": 1615387804,
+    "vulnerabilitySourceUpdatedAt": 1614955804,
+    "findingSeverityCounts": {
+      "LOW": 1
+    }
+  },
+  "registryId": "1234",
+  "repositoryName": "some-repo-name",
+  "imageId": {
+    "imageDigest": "sha256:50dc398e12245d03e0159cf3d199d6fbb615f432978b893a1322ee9ae729e629",
+    "imageTag": "intg"
+  },
+  "imageScanStatus": {
+    "status": "COMPLETE",
+    "description": "The scan was completed successfully."
+  }
+}

--- a/src/test/resources/ecr-findings/low-severity.json
+++ b/src/test/resources/ecr-findings/low-severity.json
@@ -1,0 +1,44 @@
+{
+  "imageScanFindings": {
+    "findings": [
+      {
+        "name": "CVE-2020-123456789",
+        "uri": "https://example.com/CVE-2020-123456789",
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1.2.3"
+          },
+          {
+            "key": "package_name",
+            "value": "some-dependency"
+          },
+          {
+            "key": "CVSS2_VECTOR",
+            "value": "AV:L/AC:L/Au:N/C:N/I:N/A:P"
+          },
+          {
+            "key": "CVSS2_SCORE",
+            "value": "2.1"
+          }
+        ]
+      }
+    ],
+    "imageScanCompletedAt": 1615387804,
+    "vulnerabilitySourceUpdatedAt": 1614955804,
+    "findingSeverityCounts": {
+      "LOW": 1
+    }
+  },
+  "registryId": "1234",
+  "repositoryName": "some-repo-name",
+  "imageId": {
+    "imageDigest": "sha256:50dc398e12245d03e0159cf3d199d6fbb615f432978b893a1322ee9ae729e629",
+    "imageTag": "intg"
+  },
+  "imageScanStatus": {
+    "status": "COMPLETE",
+    "description": "The scan was completed successfully."
+  }
+}

--- a/src/test/resources/ecr-findings/mixed-severity.json
+++ b/src/test/resources/ecr-findings/mixed-severity.json
@@ -1,0 +1,519 @@
+{
+  "imageScanFindings": {
+    "findings": [
+      {
+        "name": "RHSA-2020:4952",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "CRITICAL",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.9.1-4.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "freetype"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:5476",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "HIGH",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:1.1.1c-15.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "openssl"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:5476",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "HIGH",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:1.1.1c-15.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "openssl-libs"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4599",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "7.61.1-12.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "curl"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4497",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.1.27-1.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "cyrus-sasl-lib"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4484",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.2.5-3.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "expat"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4444",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.28-101.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "glibc"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4444",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.28-101.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "glibc-common"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4444",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.28-101.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "glibc-langpack-en"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4444",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.28-101.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "glibc-minimal-langpack"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4490",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.2.9-1.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "gnupg2"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:5483",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.6.8-11.el8_2"
+          },
+          {
+            "key": "package_name",
+            "value": "gnutls"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4305",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:11.0.8.10-0.el8_2"
+          },
+          {
+            "key": "package_name",
+            "value": "java-11-openjdk-headless"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4443",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.3.2-8.el8_1"
+          },
+          {
+            "key": "package_name",
+            "value": "libarchive"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4599",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "7.61.1-12.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libcurl"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4482",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1.8.3-4.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libgcrypt"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4508",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "0.7.7-1.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libsolv"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4545",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "0.9.0-4.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libssh"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4545",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "0.9.0-4.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libssh-config"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4479",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "2.9.7-7.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "libxml2"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4539",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "10.32-1.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "pcre2"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4433",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.6.8-23.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "platform-python"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4432",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "9.0.3-16.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "platform-python-pip"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4433",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.6.8-23.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "python3-libs"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4432",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "9.0.3-16.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "python3-pip"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4432",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "9.0.3-16.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "python3-pip-wheel"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4442",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "MEDIUM",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "3.26.0-6.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "sqlite-libs"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4469",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:2.2.6-33.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "cups-libs"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4514",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:1.1.1c-15.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "openssl"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4514",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1:1.1.1c-15.el8"
+          },
+          {
+            "key": "package_name",
+            "value": "openssl-libs"
+          }
+        ]
+      },
+      {
+        "name": "RHSA-2020:4553",
+        "description": "Some vulnerability description"
+        "uri": "https://example.com",
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "239-31.el8_2.2"
+          },
+          {
+            "key": "package_name",
+            "value": "systemd-libs"
+          }
+        ]
+      }
+    ],
+    "imageScanCompletedAt": 1615279785,
+    "vulnerabilitySourceUpdatedAt": 1615203847,
+    "findingSeverityCounts": {
+      "MEDIUM": 24,
+      "LOW": 4,
+      "HIGH": 3
+    }
+  },
+  "registryId": "1234",
+  "repositoryName": "some-repo-name",
+  "imageId": {
+    "imageDigest": "sha256:ca236bc619f5513544fbae8873a58a46485742428934de7483d16f60ce052b4b",
+    "imageTag": "intg"
+  },
+  "imageScanStatus": {
+    "status": "COMPLETE",
+    "description": "The scan was completed successfully."
+  }
+}

--- a/src/test/resources/ecr-findings/mixed-severity.json
+++ b/src/test/resources/ecr-findings/mixed-severity.json
@@ -3,7 +3,7 @@
     "findings": [
       {
         "name": "RHSA-2020:4952",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "CRITICAL",
         "attributes": [
@@ -19,7 +19,7 @@
       },
       {
         "name": "RHSA-2020:5476",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "HIGH",
         "attributes": [
@@ -35,7 +35,7 @@
       },
       {
         "name": "RHSA-2020:5476",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "HIGH",
         "attributes": [
@@ -51,7 +51,7 @@
       },
       {
         "name": "RHSA-2020:4599",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -67,7 +67,7 @@
       },
       {
         "name": "RHSA-2020:4497",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -83,7 +83,7 @@
       },
       {
         "name": "RHSA-2020:4484",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -99,7 +99,7 @@
       },
       {
         "name": "RHSA-2020:4444",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -115,7 +115,7 @@
       },
       {
         "name": "RHSA-2020:4444",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -131,7 +131,7 @@
       },
       {
         "name": "RHSA-2020:4444",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -147,7 +147,7 @@
       },
       {
         "name": "RHSA-2020:4444",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -163,7 +163,7 @@
       },
       {
         "name": "RHSA-2020:4490",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -179,7 +179,7 @@
       },
       {
         "name": "RHSA-2020:5483",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -195,7 +195,7 @@
       },
       {
         "name": "RHSA-2020:4305",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -211,7 +211,7 @@
       },
       {
         "name": "RHSA-2020:4443",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -227,7 +227,7 @@
       },
       {
         "name": "RHSA-2020:4599",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -243,7 +243,7 @@
       },
       {
         "name": "RHSA-2020:4482",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -259,7 +259,7 @@
       },
       {
         "name": "RHSA-2020:4508",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -275,7 +275,7 @@
       },
       {
         "name": "RHSA-2020:4545",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -291,7 +291,7 @@
       },
       {
         "name": "RHSA-2020:4545",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -307,7 +307,7 @@
       },
       {
         "name": "RHSA-2020:4479",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -323,7 +323,7 @@
       },
       {
         "name": "RHSA-2020:4539",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -339,7 +339,7 @@
       },
       {
         "name": "RHSA-2020:4433",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -355,7 +355,7 @@
       },
       {
         "name": "RHSA-2020:4432",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -371,7 +371,7 @@
       },
       {
         "name": "RHSA-2020:4433",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -387,7 +387,7 @@
       },
       {
         "name": "RHSA-2020:4432",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -403,7 +403,7 @@
       },
       {
         "name": "RHSA-2020:4432",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -419,7 +419,7 @@
       },
       {
         "name": "RHSA-2020:4442",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "MEDIUM",
         "attributes": [
@@ -435,7 +435,7 @@
       },
       {
         "name": "RHSA-2020:4469",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "LOW",
         "attributes": [
@@ -451,7 +451,7 @@
       },
       {
         "name": "RHSA-2020:4514",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "LOW",
         "attributes": [
@@ -467,7 +467,7 @@
       },
       {
         "name": "RHSA-2020:4514",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "LOW",
         "attributes": [
@@ -483,7 +483,7 @@
       },
       {
         "name": "RHSA-2020:4553",
-        "description": "Some vulnerability description"
+        "description": "Some vulnerability description",
         "uri": "https://example.com",
         "severity": "LOW",
         "attributes": [

--- a/src/test/resources/ecr-findings/muted-vulnerability.json
+++ b/src/test/resources/ecr-findings/muted-vulnerability.json
@@ -1,0 +1,44 @@
+{
+  "imageScanFindings": {
+    "findings": [
+      {
+        "name": "CVE-2020-98765",
+        "uri": "https://example.com/CVE-2020-98765",
+        "severity": "LOW",
+        "attributes": [
+          {
+            "key": "package_version",
+            "value": "1.2.3"
+          },
+          {
+            "key": "package_name",
+            "value": "some-dependency"
+          },
+          {
+            "key": "CVSS2_VECTOR",
+            "value": "AV:L/AC:L/Au:N/C:N/I:N/A:P"
+          },
+          {
+            "key": "CVSS2_SCORE",
+            "value": "2.1"
+          }
+        ]
+      }
+    ],
+    "imageScanCompletedAt": 1615387804,
+    "vulnerabilitySourceUpdatedAt": 1614955804,
+    "findingSeverityCounts": {
+      "LOW": 1
+    }
+  },
+  "registryId": "1234",
+  "repositoryName": "some-repo-name",
+  "imageId": {
+    "imageDigest": "sha256:50dc398e12245d03e0159cf3d199d6fbb615f432978b893a1322ee9ae729e629",
+    "imageTag": "intg"
+  },
+  "imageScanStatus": {
+    "status": "COMPLETE",
+    "description": "The scan was completed successfully."
+  }
+}

--- a/src/test/resources/ecr-findings/no-findings.json
+++ b/src/test/resources/ecr-findings/no-findings.json
@@ -1,0 +1,18 @@
+{
+  "imageScanFindings": {
+    "findings": [],
+    "imageScanCompletedAt": 1615279785,
+    "vulnerabilitySourceUpdatedAt": 1615203847,
+    "findingSeverityCounts": {}
+  },
+  "registryId": "1234",
+  "repositoryName": "some-repo-name",
+  "imageId": {
+    "imageDigest": "sha256:0dd8216bcde6a8c286f797f3ea79faa6ee1dabcbd663470b0e54b2aec56285da",
+    "imageTag": "intg"
+  },
+  "imageScanStatus": {
+    "status": "COMPLETE",
+    "description": "The scan was completed successfully."
+  }
+}

--- a/src/test/resources/ecr-findings/undefined-severity.json
+++ b/src/test/resources/ecr-findings/undefined-severity.json
@@ -1,0 +1,27 @@
+{
+  "imageScanFindings": {
+    "findings": [
+      {
+        "name": "CVE-2020-123456789",
+        "uri": "https://example.com/CVE-2020-123456789",
+        "severity": "UNDEFINED",
+        "attributes": []
+      }
+    ],
+    "imageScanCompletedAt": 1615387804,
+    "vulnerabilitySourceUpdatedAt": 1614955804,
+    "findingSeverityCounts": {
+      "LOW": 1
+    }
+  },
+  "registryId": "1234",
+  "repositoryName": "some-repo-name",
+  "imageId": {
+    "imageDigest": "sha256:50dc398e12245d03e0159cf3d199d6fbb615f432978b893a1322ee9ae729e629",
+    "imageTag": "intg"
+  },
+  "imageScanStatus": {
+    "status": "COMPLETE",
+    "description": "The scan was completed successfully."
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
@@ -26,6 +26,20 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       stubEcrApiResponse(lowSeverityEvent.detail.imageDigest, lowSeverityFindings)
     ),
     (
+      "an ECR scan of 'latest' with only undefined severity vulnerabilities",
+      scanEventInputText(undefinedSeverityEvent),
+      None,
+      None,
+      stubEcrApiResponse(undefinedSeverityEvent.detail.imageDigest, undefinedFindings)
+    ),
+    (
+      "an ECR scan of 'latest' with only informational vulnerabilities",
+      scanEventInputText(informationalEvent),
+      None,
+      None,
+      stubEcrApiResponse(informationalEvent.detail.imageDigest, informationalFindings)
+    ),
+    (
       "an ECR scan of 'latest' with no results",
       scanEventInputText(noVulnerabilitiesEvent),
       None,
@@ -64,17 +78,23 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
 
   private lazy val mixedSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd1", mixedCounts))
   private lazy val lowSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd2", lowSeverityCounts))
+  private lazy val informationalEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "1234", informationalCounts))
+  private lazy val undefinedSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "1234", undefinedSeverityCounts))
   private lazy val noVulnerabilitiesEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd3", emptyCounts))
   private lazy val otherTagEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("anothertag"), "abcd4", emptyCounts))
   private lazy val intgTagEmptyEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("intg"), "abcd5", zeroCounts))
 
-  private lazy val mixedCounts = ScanFindingCounts(10, 100, 1000, 10000)
-  private lazy val lowSeverityCounts = ScanFindingCounts(0, 0, 0, 10)
-  private lazy val emptyCounts = ScanFindingCounts(0, 0, 0, 0)
-  private lazy val zeroCounts = ScanFindingCounts(0, 0, 0, 0)
+  private lazy val mixedCounts = ScanFindingCounts(10, 100, 1000, 10000, 10, 1)
+  private lazy val lowSeverityCounts = ScanFindingCounts(0, 0, 0, 10, 0, 0)
+  private lazy val informationalCounts = ScanFindingCounts(0, 0, 0, 0, 10, 0)
+  private lazy val undefinedSeverityCounts = ScanFindingCounts(0, 0, 0, 0, 0, 10)
+  private lazy val emptyCounts = ScanFindingCounts(0, 0, 0, 0, 0, 0)
+  private lazy val zeroCounts = ScanFindingCounts(0, 0, 0, 0, 0, 0)
 
   private lazy val mixedSeverityFindings = Source.fromResource("ecr-findings/mixed-severity.json").getLines.mkString
   private lazy val lowSeverityFindings = Source.fromResource("ecr-findings/low-severity.json").getLines.mkString
+  private lazy val undefinedFindings = Source.fromResource("ecr-findings/undefined-severity.json").getLines.mkString
+  private lazy val informationalFindings = Source.fromResource("ecr-findings/informational.json").getLines.mkString
   private lazy val noFindings = Source.fromResource("ecr-findings/no-findings.json").getLines.mkString
   private lazy val findingsWithOnlyMutedVulnerability = Source.fromResource("ecr-findings/muted-vulnerability.json").getLines.mkString
   private lazy val findingsIncludingMutedVulnerability = Source.fromResource("ecr-findings/including-muted-vulnerability.json").getLines.mkString

--- a/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
@@ -14,11 +14,11 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec {
     ("an ECR scan of 'intg' with no results", scanEventInputText(scanEvent5), None, None)
   )
 
-  private lazy val scanEvent1: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(Some(10), Some(100), Some(1000), Some(10000))))
-  private lazy val scanEvent2: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(Option.empty, Some(0), Option.empty, Some(10))))
-  private lazy val scanEvent3: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(Option.empty, Option.empty, Option.empty, Option.empty)))
-  private lazy val scanEvent4: ScanEvent = ScanEvent(ScanDetail("", List("anothertag"), ScanFindingCounts(Option.empty, Option.empty, Option.empty, Option.empty)))
-  private lazy val scanEvent5: ScanEvent = ScanEvent(ScanDetail("", List("intg"), ScanFindingCounts(Some(0), Some(0), Some(0), Some(0))))
+  private lazy val scanEvent1: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(10, 100, 1000, 10000)))
+  private lazy val scanEvent2: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(0, 0, 0, 10)))
+  private lazy val scanEvent3: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(0, 0, 0, 0)))
+  private lazy val scanEvent4: ScanEvent = ScanEvent(ScanDetail("", List("anothertag"), ScanFindingCounts(0, 0, 0, 0)))
+  private lazy val scanEvent5: ScanEvent = ScanEvent(ScanDetail("", List("intg"), ScanFindingCounts(0, 0, 0, 0)))
 
   private def expectedEmailBody(scanEvent: ScanEvent): String = {
     val (critical, high, medium, low) = getCounts(scanEvent)
@@ -86,10 +86,10 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec {
 
 object EcrScanIntegrationSpec {
   private def getCounts(scanEvent: ScanEvent): (Int, Int, Int, Int) = {
-    val critical = scanEvent.detail.findingSeverityCounts.critical.getOrElse(0)
-    val high = scanEvent.detail.findingSeverityCounts.high.getOrElse(0)
-    val medium = scanEvent.detail.findingSeverityCounts.medium.getOrElse(0)
-    val low = scanEvent.detail.findingSeverityCounts.low.getOrElse(0)
+    val critical = scanEvent.detail.findingSeverityCounts.critical
+    val high = scanEvent.detail.findingSeverityCounts.high
+    val medium = scanEvent.detail.findingSeverityCounts.medium
+    val low = scanEvent.detail.findingSeverityCounts.low
     (critical, high, medium, low)
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
@@ -1,35 +1,103 @@
 package uk.gov.nationalarchives.notifications
 
-import org.scalatest.prop.TableFor4
-import uk.gov.nationalarchives.notifications.EcrScanIntegrationSpec.{getCounts, scanEventInputText}
+import com.github.tomakehurst.wiremock.client.WireMock._
+import org.scalatest.prop.TableFor5
+import uk.gov.nationalarchives.notifications.EcrScanIntegrationSpec.scanEventInputText
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.{ScanDetail, ScanEvent, ScanFindingCounts}
 
-class EcrScanIntegrationSpec extends LambdaIntegrationSpec {
-  override lazy val events: TableFor4[String, String, Option[String], Option[String]] = Table(
-    ("description", "input", "emailBody", "slackBody"),
-    ("an ECR scan of 'latest' with a mix of severities", scanEventInputText(scanEvent1), Some(expectedEmailBody(scanEvent1)), Some(expectedSlackBody(scanEvent1))),
-    ("an ECR scan of 'latest' with only low severity vulnerabilities", scanEventInputText(scanEvent2), Some(expectedEmailBody(scanEvent2)), Some(expectedSlackBody(scanEvent2))),
-    ("an ECR scan of 'latest' with no results", scanEventInputText(scanEvent3), None, None),
-    ("an ECR scan of an image with a non-deployment tag", scanEventInputText(scanEvent4), None, None),
-    ("an ECR scan of 'intg' with no results", scanEventInputText(scanEvent5), None, None)
+import scala.io.Source
+
+class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
+
+  override lazy val events: TableFor5[String, String, Option[String], Option[String], () => ()] = Table(
+    ("description", "input", "emailBody", "slackBody", "stubContext"),
+    (
+      "an ECR scan of 'latest' with a mix of severities",
+      scanEventInputText(mixedSeverityEvent),
+      Some(expectedEmailBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 4))),
+      Some(expectedSlackBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 4))),
+      stubEcrApiResponse(mixedSeverityEvent.detail.imageDigest, mixedSeverityFindings)
+    ),
+    (
+      "an ECR scan of 'latest' with only low severity vulnerabilities",
+      scanEventInputText(lowSeverityEvent),
+      Some(expectedEmailBody(lowSeverityEvent, ExpectedFindings(0, 0, 0, 1))),
+      Some(expectedSlackBody(lowSeverityEvent, ExpectedFindings(0, 0, 0, 1))),
+      stubEcrApiResponse(lowSeverityEvent.detail.imageDigest, lowSeverityFindings)
+    ),
+    (
+      "an ECR scan of 'latest' with no results",
+      scanEventInputText(noVulnerabilitiesEvent),
+      None,
+      None,
+      stubEcrApiResponse(noVulnerabilitiesEvent.detail.imageDigest, noFindings)
+    ),
+    (
+      "an ECR scan of an image with a non-deployment tag",
+      scanEventInputText(otherTagEvent),
+      None,
+      None,
+      stubEcrApiResponse(otherTagEvent.detail.imageDigest, lowSeverityFindings)
+    ),
+    (
+      "an ECR scan of 'intg' with no results",
+      scanEventInputText(intgTagEmptyEvent),
+      None,
+      None,
+      stubEcrApiResponse(intgTagEmptyEvent.detail.imageDigest, noFindings)
+    ),
+    (
+      "an ECR scan which only contains a muted vulnerability",
+      scanEventInputText(lowSeverityEvent),
+      None,
+      None,
+      stubEcrApiResponse(lowSeverityEvent.detail.imageDigest, findingsWithOnlyMutedVulnerability)
+    ),
+    (
+      "an ECR scan with a mix of muted and non-muted vulnerabilities",
+      scanEventInputText(mixedSeverityEvent),
+      Some(expectedEmailBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 3))),
+      Some(expectedSlackBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 3))),
+      stubEcrApiResponse(mixedSeverityEvent.detail.imageDigest, findingsIncludingMutedVulnerability)
+    ),
   )
 
-  private lazy val scanEvent1: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(10, 100, 1000, 10000)))
-  private lazy val scanEvent2: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(0, 0, 0, 10)))
-  private lazy val scanEvent3: ScanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(0, 0, 0, 0)))
-  private lazy val scanEvent4: ScanEvent = ScanEvent(ScanDetail("", List("anothertag"), ScanFindingCounts(0, 0, 0, 0)))
-  private lazy val scanEvent5: ScanEvent = ScanEvent(ScanDetail("", List("intg"), ScanFindingCounts(0, 0, 0, 0)))
+  private lazy val mixedSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd1", mixedCounts))
+  private lazy val lowSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd2", lowSeverityCounts))
+  private lazy val noVulnerabilitiesEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd3", emptyCounts))
+  private lazy val otherTagEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("anothertag"), "abcd4", emptyCounts))
+  private lazy val intgTagEmptyEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("intg"), "abcd5", zeroCounts))
 
-  private def expectedEmailBody(scanEvent: ScanEvent): String = {
-    val (critical, high, medium, low) = getCounts(scanEvent)
+  private lazy val mixedCounts = ScanFindingCounts(10, 100, 1000, 10000)
+  private lazy val lowSeverityCounts = ScanFindingCounts(0, 0, 0, 10)
+  private lazy val emptyCounts = ScanFindingCounts(0, 0, 0, 0)
+  private lazy val zeroCounts = ScanFindingCounts(0, 0, 0, 0)
+
+  private lazy val mixedSeverityFindings = Source.fromResource("ecr-findings/mixed-severity.json").getLines.mkString
+  private lazy val lowSeverityFindings = Source.fromResource("ecr-findings/low-severity.json").getLines.mkString
+  private lazy val noFindings = Source.fromResource("ecr-findings/no-findings.json").getLines.mkString
+  private lazy val findingsWithOnlyMutedVulnerability = Source.fromResource("ecr-findings/muted-vulnerability.json").getLines.mkString
+  private lazy val findingsIncludingMutedVulnerability = Source.fromResource("ecr-findings/including-muted-vulnerability.json").getLines.mkString
+
+  case class ExpectedFindings(critical: Int, high: Int, medium: Int, low: Int)
+
+  private def stubEcrApiResponse(sha256Digest: String, response: String): () => () = () => {
+    ecrApiEndpoint.stubFor(post(urlEqualTo("/"))
+      .withRequestBody(matchingJsonPath("$.repositoryName", equalTo("repo-name")))
+      .withRequestBody(matchingJsonPath("$.imageId.imageDigest", equalTo(sha256Digest)))
+      .willReturn(ok(response))
+    )
+  }
+
+  private def expectedEmailBody(scanEvent: ScanEvent, expectedFindings: ExpectedFindings): String = {
     "Action=SendEmail&Version=2010-12-01&Source=scanresults%40tdr-management.nationalarchives.gov.uk" +
       "&Destination.ToAddresses.member.1=aws_tdr_management%40nationalarchives.gov.uk" +
-      "&Message.Subject.Data=ECR+scan+results+for+yara-dependencies&Message.Subject.Charset=UTF-8" +
-      "&Message.Body.Html.Data=%3Chtml%3E%3Cbody%3E%3Ch1%3EImage+scan+results+for+yara-dependencies%3C%2Fh1%3E%3Cdiv%3E%3Cp%3E" +
-      s"$critical+critical+vulnerabilities%3C%2Fp%3E%3Cp%3E" +
-      s"$high+high+vulnerabilities%3C%2Fp%3E%3Cp%3E" +
-      s"$medium+medium+vulnerabilities%3C%2Fp%3E%3Cp%3E" +
-      s"$low+low+vulnerabilities%3C%2Fp%3E%3C%2Fdiv%3E" +
+      s"&Message.Subject.Data=ECR+scan+results+for+${scanEvent.detail.repositoryName}&Message.Subject.Charset=UTF-8" +
+      s"&Message.Body.Html.Data=%3Chtml%3E%3Cbody%3E%3Ch1%3EImage+scan+results+for+${scanEvent.detail.repositoryName}%3C%2Fh1%3E%3Cdiv%3E%3Cp%3E" +
+      s"${expectedFindings.critical}+critical+vulnerabilities%3C%2Fp%3E%3Cp%3E" +
+      s"${expectedFindings.high}+high+vulnerabilities%3C%2Fp%3E%3Cp%3E" +
+      s"${expectedFindings.medium}+medium+vulnerabilities%3C%2Fp%3E%3Cp%3E" +
+      s"${expectedFindings.low}+low+vulnerabilities%3C%2Fp%3E%3C%2Fdiv%3E" +
       "%3Cdiv%3E%3Cp%3E" +
       "See+the+TDR+developer+manual+for+guidance+on+fixing+these+vulnerabilities%3A+" +
       "https%3A%2F%2Fgithub.com%2Fnationalarchives%2Ftdr-dev-documentation%2Fblob%2Fmaster%2Fmanual%2Falerts%2Fecr-scans.md" +
@@ -38,39 +106,38 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec {
       "&Message.Body.Html.Charset=UTF-8"
   }
 
-  private def expectedSlackBody(scanEvent: ScanEvent): String = {
-    val (critical, high, medium, low) = getCounts(scanEvent)
+  private def expectedSlackBody(scanEvent: ScanEvent, expectedFindings: ExpectedFindings): String = {
     s"""
        |{
        |  "blocks" : [ {
        |    "type" : "section",
        |    "text" : {
        |      "type" : "mrkdwn",
-       |      "text" : "*ECR image scan complete on image yara-dependencies ${scanEvent.detail.tags.mkString(",")}*"
+       |      "text" : "*ECR image scan complete on image ${scanEvent.detail.repositoryName} ${scanEvent.detail.tags.mkString(",")}*"
        |    }
        |  }, {
        |    "type" : "section",
        |    "text" : {
        |      "type" : "mrkdwn",
-       |      "text" : "$critical critical severity vulnerabilities"
+       |      "text" : "${expectedFindings.critical} critical severity vulnerabilities"
        |    }
        |  }, {
        |    "type" : "section",
        |    "text" : {
        |      "type" : "mrkdwn",
-       |      "text" : "$high high severity vulnerabilities"
+       |      "text" : "${expectedFindings.high} high severity vulnerabilities"
        |    }
        |  }, {
        |    "type" : "section",
        |    "text" : {
        |      "type" : "mrkdwn",
-       |      "text" : "$medium medium severity vulnerabilities"
+       |      "text" : "${expectedFindings.medium} medium severity vulnerabilities"
        |    }
        |  }, {
        |    "type" : "section",
        |    "text" : {
        |      "type" : "mrkdwn",
-       |      "text" : "$low low severity vulnerabilities"
+       |      "text" : "${expectedFindings.low} low severity vulnerabilities"
        |    }
        |  }, {
        |    "type" : "section",
@@ -99,8 +166,9 @@ object EcrScanIntegrationSpec {
        |{
        |  "detail": {
        |    "scan-status": "COMPLETE",
-       |    "repository-name": "yara-dependencies",
-       |    "image-tags" : ["${scanEvent.detail.tags.mkString("\",\"")}"],
+       |    "repository-name": "${scanEvent.detail.repositoryName}",
+       |    "image-tags": ["${scanEvent.detail.tags.mkString("\",\"")}"],
+       |    "image-digest": "${scanEvent.detail.imageDigest}",
        |    "finding-severity-counts": {
        |      "CRITICAL": $critical,
        |      "HIGH": $high,

--- a/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
@@ -2,18 +2,18 @@ package uk.gov.nationalarchives.notifications
 
 import java.util.UUID
 
-import org.scalatest.prop.TableFor4
+import org.scalatest.prop.TableFor5
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.{ExportStatusEvent, ExportSuccessDetails}
 
 class ExportIntegrationSpec extends LambdaIntegrationSpec {
-  override lazy val events: TableFor4[String, String, Option[String], Option[String]] = Table(
-    ("description", "input", "emailBody", "slackBody"),
-    ("a successful export event on intg", exportStatusEventInputText(exportStatus1), None, None),
-    ("a failed export event on intg", exportStatusEventInputText(exportStatus2), None, Some(expectedSlackMessage(exportStatus2))),
-    ("a successful export event on staging", exportStatusEventInputText(exportStatus3), None, Some(expectedSlackMessage(exportStatus3))),
-    ("a failed export event on staging", exportStatusEventInputText(exportStatus4), None, Some(expectedSlackMessage(exportStatus4))),
-    ("a failed export on intg with no error details", exportStatusEventInputText(exportStatus5), None, Some(expectedSlackMessage(exportStatus5))),
-    ("a failed export on staging with no error details", exportStatusEventInputText(exportStatus6), None, Some(expectedSlackMessage(exportStatus6))),
+  override lazy val events: TableFor5[String, String, Option[String], Option[String], () => ()] = Table(
+    ("description", "input", "emailBody", "slackBody", "stubContext"),
+    ("a successful export event on intg", exportStatusEventInputText(exportStatus1), None, None, () => ()),
+    ("a failed export event on intg", exportStatusEventInputText(exportStatus2), None, Some(expectedSlackMessage(exportStatus2)), () => ()),
+    ("a successful export event on staging", exportStatusEventInputText(exportStatus3), None, Some(expectedSlackMessage(exportStatus3)), () => ()),
+    ("a failed export event on staging", exportStatusEventInputText(exportStatus4), None, Some(expectedSlackMessage(exportStatus4)), () => ()),
+    ("a failed export on intg with no error details", exportStatusEventInputText(exportStatus5), None, Some(expectedSlackMessage(exportStatus5)), () => ()),
+    ("a failed export on staging with no error details", exportStatusEventInputText(exportStatus6), None, Some(expectedSlackMessage(exportStatus6)), () => ()),
   )
 
   private lazy val successDetails = ExportSuccessDetails(UUID.randomUUID(), "consignmentRef1", "tb-body1")

--- a/src/test/scala/uk/gov/nationalarchives/notifications/JenkinsBackupIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/JenkinsBackupIntegrationSpec.scala
@@ -1,14 +1,14 @@
 package uk.gov.nationalarchives.notifications
 
-import org.scalatest.prop.TableFor4
+import org.scalatest.prop.TableFor5
 import uk.gov.nationalarchives.notifications.decoders.SSMMaintenanceDecoder.SSMMaintenanceEvent
 
 class JenkinsBackupIntegrationSpec extends LambdaIntegrationSpec {
 
-  override lazy val events: TableFor4[String, String, Option[String], Option[String]] = Table(
-    ("description", "input", "emailBody", "slackBody"),
-    ("a successful Jenkins backup event", maintenanceEventInputText(maintenanceResult1), None, None),
-    ("a failed Jenkins backup event", maintenanceEventInputText(maintenanceResult2), None, Some(expectedBackupFailureSlackMessage))
+  override lazy val events: TableFor5[String, String, Option[String], Option[String], () => ()] = Table(
+    ("description", "input", "emailBody", "slackBody", "stubContext"),
+    ("a successful Jenkins backup event", maintenanceEventInputText(maintenanceResult1), None, None, () => ()),
+    ("a failed Jenkins backup event", maintenanceEventInputText(maintenanceResult2), None, Some(expectedBackupFailureSlackMessage), () => ())
   )
 
   private lazy val maintenanceResult1: SSMMaintenanceEvent = SSMMaintenanceEvent(true)

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
@@ -6,7 +6,7 @@ import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.{ScanDetail, S
 class LambdaErrorSpec extends LambdaSpecUtils {
 
   "the process method" should "error if the ses service is unavailable" in {
-    val scanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(Some(10), Some(100), Some(1000), Some(10000))))
+    val scanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(10, 100, 1000, 10000)))
     val stream = new java.io.ByteArrayInputStream(scanEventInputText(scanEvent).getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
     wiremockSesEndpoint.resetAll()
     val exception = intercept[Exception] {
@@ -16,7 +16,7 @@ class LambdaErrorSpec extends LambdaSpecUtils {
   }
 
   "the process method" should "error if the slack service is unavailable" in {
-    val scanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(Some(10), Some(100), Some(1000), Some(10000))))
+    val scanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(10, 100, 1000, 10000)))
     val stream = new java.io.ByteArrayInputStream(scanEventInputText(scanEvent).getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
     wiremockSlackServer.resetAll()
     val exception = intercept[Exception] {

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
@@ -14,7 +14,7 @@ class LambdaErrorSpec extends LambdaSpecUtils with MockEcrApi {
     ecrApiEndpoint.stubFor(post(urlEqualTo("/"))
       .willReturn(ok(ecrApiResponse)))
 
-    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000)))
+    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000, 1, 10)))
     val stream = new java.io.ByteArrayInputStream(scanEventInputText(scanEvent).getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
     wiremockSesEndpoint.resetAll()
     val exception = intercept[Exception] {
@@ -27,7 +27,7 @@ class LambdaErrorSpec extends LambdaSpecUtils with MockEcrApi {
     ecrApiEndpoint.stubFor(post(urlEqualTo("/"))
       .willReturn(ok(ecrApiResponse)))
 
-    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000)))
+    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000, 1, 10)))
     val stream = new java.io.ByteArrayInputStream(scanEventInputText(scanEvent).getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
     wiremockSlackServer.resetAll()
     val exception = intercept[Exception] {

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
@@ -1,12 +1,20 @@
 package uk.gov.nationalarchives.notifications
 
+import com.github.tomakehurst.wiremock.client.WireMock.{ok, post, urlEqualTo}
 import uk.gov.nationalarchives.notifications.EcrScanIntegrationSpec.scanEventInputText
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.{ScanDetail, ScanEvent, ScanFindingCounts}
 
-class LambdaErrorSpec extends LambdaSpecUtils {
+import scala.io.Source
+
+class LambdaErrorSpec extends LambdaSpecUtils with MockEcrApi {
+
+  private val ecrApiResponse = Source.fromResource("ecr-findings/low-severity.json").getLines.mkString
 
   "the process method" should "error if the ses service is unavailable" in {
-    val scanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(10, 100, 1000, 10000)))
+    ecrApiEndpoint.stubFor(post(urlEqualTo("/"))
+      .willReturn(ok(ecrApiResponse)))
+
+    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000)))
     val stream = new java.io.ByteArrayInputStream(scanEventInputText(scanEvent).getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
     wiremockSesEndpoint.resetAll()
     val exception = intercept[Exception] {
@@ -16,7 +24,10 @@ class LambdaErrorSpec extends LambdaSpecUtils {
   }
 
   "the process method" should "error if the slack service is unavailable" in {
-    val scanEvent = ScanEvent(ScanDetail("", List("latest"), ScanFindingCounts(10, 100, 1000, 10000)))
+    ecrApiEndpoint.stubFor(post(urlEqualTo("/"))
+      .willReturn(ok(ecrApiResponse)))
+
+    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000)))
     val stream = new java.io.ByteArrayInputStream(scanEventInputText(scanEvent).getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
     wiremockSlackServer.resetAll()
     val exception = intercept[Exception] {

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaIntegrationSpec.scala
@@ -1,16 +1,17 @@
 package uk.gov.nationalarchives.notifications
 
 import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, postRequestedFor, urlEqualTo}
-import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor4}
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor5}
 
 trait LambdaIntegrationSpec extends LambdaSpecUtils with TableDrivenPropertyChecks {
-  def events: TableFor4[String, String, Option[String], Option[String]]
+  def events: TableFor5[String, String, Option[String], Option[String], () => ()]
 
   forAll(events) {
-    (description, input, emailBody, slackBody) => {
+    (description, input, emailBody, slackBody, stubContext) => {
       emailBody match {
         case Some(body) =>
           "the process method" should s"send an email message for $description" in {
+            stubContext()
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
             wiremockSesEndpoint.verify(1,
@@ -20,6 +21,7 @@ trait LambdaIntegrationSpec extends LambdaSpecUtils with TableDrivenPropertyChec
           }
         case None =>
           "the process method" should s"not send an email message for $description" in {
+            stubContext()
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
             wiremockSesEndpoint.verify(0, postRequestedFor(urlEqualTo("/")))
@@ -29,6 +31,7 @@ trait LambdaIntegrationSpec extends LambdaSpecUtils with TableDrivenPropertyChec
       slackBody match {
         case Some(body) =>
           "the process method" should s"send a slack message for $description" in {
+            stubContext()
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
             wiremockSlackServer.verify(slackBody.size,
@@ -38,6 +41,7 @@ trait LambdaIntegrationSpec extends LambdaSpecUtils with TableDrivenPropertyChec
           }
         case None =>
           "the process method" should s"not send a slack message for $description" in {
+            stubContext()
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
             wiremockSlackServer.verify(0,

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaSpecUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaSpecUtils.scala
@@ -25,20 +25,28 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
           |  </ResponseMetadata>
           |</SendEmailResponse>
           |""".stripMargin)))
+
+    super.beforeEach()
   }
 
   override def afterEach(): Unit = {
     wiremockSlackServer.resetAll()
     wiremockSesEndpoint.resetAll()
+
+    super.afterEach()
   }
 
   override def beforeAll(): Unit = {
     wiremockSlackServer.start()
     wiremockSesEndpoint.start()
+
+    super.beforeAll()
   }
 
   override def afterAll(): Unit = {
     wiremockSlackServer.stop()
     wiremockSesEndpoint.stop()
+
+    super.afterAll()
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/notifications/MockEcrApi.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/MockEcrApi.scala
@@ -1,0 +1,24 @@
+package uk.gov.nationalarchives.notifications
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+trait MockEcrApi extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfterEach {
+  val ecrApiEndpoint = new WireMockServer(9003)
+
+  override def afterEach(): Unit = {
+    ecrApiEndpoint.resetAll()
+    super.afterEach()
+  }
+
+  override def beforeAll(): Unit = {
+    ecrApiEndpoint.start()
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    ecrApiEndpoint.stop()
+    super.afterAll()
+  }
+}


### PR DESCRIPTION
When an ECR scan event arrives, fetch the names of the vulnerabilities from the AWS API. Compare them with a list
of muted vulnerabilities, and only send an alert for ones which are not muted.

This helps us in the case where a low-severity vulnerability has been reported, but no fix is available yet. We can mute the vulnerability until the fix is available so that if any further alerts are sent, we know they need to be investigated.