### PR TITLE
TDR-893 Make export Slack notifications clearer

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -23,5 +23,6 @@ alerts {
   }
 }
 function {
-  name = ${AWS_LAMBDA_FUNCTION_NAME}
+  name = "arbitrary-placeholder"
+  name = ${?AWS_LAMBDA_FUNCTION_NAME}
 }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -151,11 +151,11 @@ object EventMessages {
         val exportInfoMessage = constructExportInfoMessage(incomingEvent)
 
         val message: String = if (incomingEvent.success) {
-          s":white_check_mark: *Export success for ${incomingEvent.environment} environment!* \n" +
+          s":white_check_mark: Export *success* on *${incomingEvent.environment}!* \n" +
             s"*Consignment ID:* ${incomingEvent.consignmentId}" +
             s"$exportInfoMessage"
         } else {
-          s":x: *Export failure for ${incomingEvent.environment} environment!* \n" +
+          s":x: Export *failure* on *${incomingEvent.environment}!* \n" +
           s"*Consignment ID:* ${incomingEvent.consignmentId}" +
           s"$exportInfoMessage"
         }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -151,14 +151,12 @@ object EventMessages {
         val exportInfoMessage = constructExportInfoMessage(incomingEvent)
 
         val message: String = if (incomingEvent.success) {
-          ":white_check_mark: *Export success:* \n" +
-            s"*Consignment ID:* ${incomingEvent.consignmentId} \n" +
-            s"*Environment:* ${incomingEvent.environment}: \n" +
+          s":white_check_mark: *Export success for ${incomingEvent.environment} environment!* \n" +
+            s"*Consignment ID:* ${incomingEvent.consignmentId}" +
             s"$exportInfoMessage"
         } else {
-          ":x: *Export failure:* \n" +
-          s"*Consignment ID:* ${incomingEvent.consignmentId} \n" +
-          s"*Environment:* ${incomingEvent.environment}: \n" +
+          s":x: *Export failure for ${incomingEvent.environment} environment!* \n" +
+          s"*Consignment ID:* ${incomingEvent.consignmentId}" +
           s"$exportInfoMessage"
         }
         SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", message)))).some
@@ -170,11 +168,11 @@ object EventMessages {
     private def constructExportInfoMessage(incomingEvent: ExportStatusEvent): String = {
      if (incomingEvent.successDetails.isDefined) {
         val value = incomingEvent.successDetails.get
-        s":\nUser ID: ${value.userId}" +
-        s"\nConsignment Reference: ${value.consignmentReference}" +
-        s"\nTransferring Body Code: ${value.transferringBodyCode}"
+        s"\n*User ID:* ${value.userId}" +
+        s"\n*Consignment Reference:* ${value.consignmentReference}" +
+        s"\n*Transferring Body Code:* ${value.transferringBodyCode}"
       } else if(incomingEvent.failureCause.isDefined) {
-        s":\nCause: ${incomingEvent.failureCause.get}"
+        s"\n*Cause:* ${incomingEvent.failureCause.get}"
       } else ""
     }
   }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -150,9 +150,17 @@ object EventMessages {
 
         val exportInfoMessage = constructExportInfoMessage(incomingEvent)
 
-        val message = s"The export for the consignment ${incomingEvent.consignmentId} " +
-          s"has ${if (incomingEvent.success) "completed" else "failed"} for environment ${incomingEvent.environment}" +
-          s"${exportInfoMessage}"
+        val message: String = if (incomingEvent.success) {
+          ":white_check_mark: *Export success:* \n" +
+            s"*Consignment ID:* ${incomingEvent.consignmentId} \n" +
+            s"*Environment:* ${incomingEvent.environment}: \n" +
+            s"$exportInfoMessage"
+        } else {
+          ":x: *Export failure:* \n" +
+          s"*Consignment ID:* ${incomingEvent.consignmentId} \n" +
+          s"*Environment:* ${incomingEvent.environment}: \n" +
+          s"$exportInfoMessage"
+        }
         SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", message)))).some
       } else {
         Option.empty

--- a/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
@@ -50,8 +50,8 @@ class ExportIntegrationSpec extends LambdaIntegrationSpec {
     val successDetails = exportStatusEvent.successDetails
     val failureCause = exportStatusEvent.failureCause
     val exportOutputMessage = if(successDetails.isDefined) {
-      s""":\\nUser ID: ${successDetails.get.userId}\\nConsignment Reference: ${successDetails.get.consignmentReference}\\nTransferring Body Code: ${successDetails.get.transferringBodyCode}"""
-    } else if(failureCause.isDefined) s""":\\nCause: ${failureCause.get}""" else """"""
+      s"""\\n*User ID:* ${successDetails.get.userId}\\n*Consignment Reference:* ${successDetails.get.consignmentReference}\\n*Transferring Body Code:* ${successDetails.get.transferringBodyCode}"""
+    } else if(failureCause.isDefined) s"""\\n*Cause:* ${failureCause.get}""" else """"""
 
     if (exportStatusEvent.success) {
       s"""{
@@ -59,7 +59,7 @@ class ExportIntegrationSpec extends LambdaIntegrationSpec {
          |    "type" : "section",
          |    "text" : {
          |      "type" : "mrkdwn",
-         |      "text" : ":white_check_mark: *Export success:* \\n*Consignment ID:* ${exportStatusEvent.consignmentId} \\n*Environment:* ${exportStatusEvent.environment}: \\n$exportOutputMessage"
+         |      "text" : ":white_check_mark: *Export success for ${exportStatusEvent.environment} environment!* \\n*Consignment ID:* ${exportStatusEvent.consignmentId}$exportOutputMessage"
          |    }
          |  } ]
          |}""".stripMargin
@@ -69,7 +69,7 @@ class ExportIntegrationSpec extends LambdaIntegrationSpec {
          |    "type" : "section",
          |    "text" : {
          |      "type" : "mrkdwn",
-         |      "text" : ":x: *Export failure:* \\n*Consignment ID:* ${exportStatusEvent.consignmentId} \\n*Environment:* ${exportStatusEvent.environment}: \\n$exportOutputMessage"
+         |      "text" : ":x: *Export failure for ${exportStatusEvent.environment} environment!* \\n*Consignment ID:* ${exportStatusEvent.consignmentId}$exportOutputMessage"
          |    }
          |  } ]
          |}""".stripMargin

--- a/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
@@ -53,14 +53,26 @@ class ExportIntegrationSpec extends LambdaIntegrationSpec {
       s""":\\nUser ID: ${successDetails.get.userId}\\nConsignment Reference: ${successDetails.get.consignmentReference}\\nTransferring Body Code: ${successDetails.get.transferringBodyCode}"""
     } else if(failureCause.isDefined) s""":\\nCause: ${failureCause.get}""" else """"""
 
-    s"""{
-       |  "blocks" : [ {
-       |    "type" : "section",
-       |    "text" : {
-       |      "type" : "mrkdwn",
-       |      "text" : "The export for the consignment ${exportStatusEvent.consignmentId} has ${if (exportStatusEvent.success) "completed" else "failed"} for environment ${exportStatusEvent.environment}${exportOutputMessage}"
-       |    }
-       |  } ]
-       |}""".stripMargin
+    if (exportStatusEvent.success) {
+      s"""{
+         |  "blocks" : [ {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : ":white_check_mark: *Export success:* \\n*Consignment ID:* ${exportStatusEvent.consignmentId} \\n*Environment:* ${exportStatusEvent.environment}: \\n$exportOutputMessage"
+         |    }
+         |  } ]
+         |}""".stripMargin
+    } else {
+      s"""{
+         |  "blocks" : [ {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : ":x: *Export failure:* \\n*Consignment ID:* ${exportStatusEvent.consignmentId} \\n*Environment:* ${exportStatusEvent.environment}: \\n$exportOutputMessage"
+         |    }
+         |  } ]
+         |}""".stripMargin
+    }
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
@@ -59,7 +59,7 @@ class ExportIntegrationSpec extends LambdaIntegrationSpec {
          |    "type" : "section",
          |    "text" : {
          |      "type" : "mrkdwn",
-         |      "text" : ":white_check_mark: *Export success for ${exportStatusEvent.environment} environment!* \\n*Consignment ID:* ${exportStatusEvent.consignmentId}$exportOutputMessage"
+         |      "text" : ":white_check_mark: Export *success* on *${exportStatusEvent.environment}!* \\n*Consignment ID:* ${exportStatusEvent.consignmentId}$exportOutputMessage"
          |    }
          |  } ]
          |}""".stripMargin
@@ -69,7 +69,7 @@ class ExportIntegrationSpec extends LambdaIntegrationSpec {
          |    "type" : "section",
          |    "text" : {
          |      "type" : "mrkdwn",
-         |      "text" : ":x: *Export failure for ${exportStatusEvent.environment} environment!* \\n*Consignment ID:* ${exportStatusEvent.consignmentId}$exportOutputMessage"
+         |      "text" : ":x: Export *failure* on *${exportStatusEvent.environment}!* \\n*Consignment ID:* ${exportStatusEvent.consignmentId}$exportOutputMessage"
          |    }
          |  } ]
          |}""".stripMargin


### PR DESCRIPTION
These changes are to make the export slack notifications a little easier to read. It makes the message appear differently based on whether an export completed successfully or not whilst also keeping pertinent information. 

I have also edited the appropriate tests to reflect this change.