### PR TITLE
Create separate deployments

### DIFF
--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -1,8 +1,8 @@
 library("tdr-jenkinslib")
 
 deployToLambda(
-        stage: params.STAGE,
-        libraryName: "notifications",
-        version: params.TO_DEPLOY,
-        deploymentPackageName: "notifications.jar"
+  stage: params.STAGE,
+  libraryName: "notifications",
+  version: params.TO_DEPLOY,
+  deploymentPackageName: "notifications.jar"
 )

--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -1,37 +1,8 @@
 library("tdr-jenkinslib")
-pipeline {
-  agent {
-    label "master"
-  }
-  parameters {
-    string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. '1'")
-  }
-  stages {
-    stage("Deploy lambda") {
-      agent {
-        ecs {
-          inheritFrom "aws"
-          taskrole "arn:aws:iam::${env.MANAGEMENT_ACCOUNT}:role/TDRJenkinsNodeLambdaRoleMgmt"
-        }
-      }
-      steps {
-        script {
-          def accountNumber = tdr.getAccountNumberFromStage(env.MANAGEMENT_ACCOUNT)
-          sh "python3 /deploy_lambda_from_s3.py ${accountNumber} mgmt tdr-notifications-mgmt tdr-backend-code-mgmt ${params.TO_DEPLOY}/notifications.jar"
-        }
-      }
-    }
-    stage("Update release branch") {
-      steps {
-        script {
-          def releaseBranch = "release-mgmt"
 
-          sh "git branch -f ${releaseBranch} HEAD"
-          sshagent(['github-jenkins']) {
-            sh("git push -f origin ${releaseBranch}")
-          }
-        }
-      }
-    }
-  }
-}
+deployToLambda(
+        stage: params.STAGE,
+        libraryName: "notifications",
+        version: params.TO_DEPLOY,
+        deploymentPackageName: "notifications.jar"
+)

--- a/Jenkinsfile-deploy-mgmt
+++ b/Jenkinsfile-deploy-mgmt
@@ -16,7 +16,7 @@ pipeline {
       }
       steps {
         script {
-          tdr.reportStartOfBuildToGitHub(repo, env.GIT_COMMIT)
+          tdr.reportStartOfBuildToGitHub("tdr-notifications", env.GIT_COMMIT)
           tdr.assembleAndStash("notifications")
         }
       }

--- a/Jenkinsfile-deploy-mgmt
+++ b/Jenkinsfile-deploy-mgmt
@@ -7,20 +7,6 @@ pipeline {
     string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. '1'")
   }
   stages {
-    stage("Build") {
-      agent {
-        ecs {
-          inheritFrom "transfer-frontend"
-          taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/sbtwithpostgres"
-        }
-      }
-      steps {
-        script {
-          tdr.reportStartOfBuildToGitHub("tdr-notifications", env.GIT_COMMIT)
-          tdr.assembleAndStash("notifications")
-        }
-      }
-    }
     stage("Deploy lambda") {
       agent {
         ecs {
@@ -30,15 +16,6 @@ pipeline {
       }
       steps {
         script {
-          unstash "notifications-jar"
-          tdr.copyToS3CodeBucket("notifications", versionTag)
-
-          tdr.configureJenkinsGitUser()
-
-          sh "git tag ${versionTag}"
-          sshagent(['github-jenkins']) {
-            sh("git push origin ${versionTag}")
-          }
           def accountNumber = tdr.getAccountNumberFromStage(env.MANAGEMENT_ACCOUNT)
           sh "python3 /deploy_lambda_from_s3.py ${accountNumber} mgmt tdr-notifications-mgmt tdr-backend-code-mgmt ${params.TO_DEPLOY}/notifications.jar"
         }

--- a/Jenkinsfile-deploy-mgmt
+++ b/Jenkinsfile-deploy-mgmt
@@ -7,6 +7,20 @@ pipeline {
     string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. '1'")
   }
   stages {
+    stage("Build") {
+      agent {
+        ecs {
+          inheritFrom "transfer-frontend"
+          taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/sbtwithpostgres"
+        }
+      }
+      steps {
+        script {
+          tdr.reportStartOfBuildToGitHub(repo, env.GIT_COMMIT)
+          tdr.assembleAndStash("notifications")
+        }
+      }
+    }
     stage("Deploy lambda") {
       agent {
         ecs {
@@ -16,6 +30,15 @@ pipeline {
       }
       steps {
         script {
+          unstash "notifications-jar"
+          tdr.copyToS3CodeBucket("notifications", versionTag)
+
+          tdr.configureJenkinsGitUser()
+
+          sh "git tag ${versionTag}"
+          sshagent(['github-jenkins']) {
+            sh("git push origin ${versionTag}")
+          }
           def accountNumber = tdr.getAccountNumberFromStage(env.MANAGEMENT_ACCOUNT)
           sh "python3 /deploy_lambda_from_s3.py ${accountNumber} mgmt tdr-notifications-mgmt tdr-backend-code-mgmt ${params.TO_DEPLOY}/notifications.jar"
         }

--- a/Jenkinsfile-deploy-mgmt
+++ b/Jenkinsfile-deploy-mgmt
@@ -1,0 +1,37 @@
+library("tdr-jenkinslib")
+pipeline {
+  agent {
+    label "master"
+  }
+  parameters {
+    string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. '1'")
+  }
+  stages {
+    stage("Deploy lambda") {
+      agent {
+        ecs {
+          inheritFrom "aws"
+          taskrole "arn:aws:iam::${env.MANAGEMENT_ACCOUNT}:role/TDRJenkinsNodeLambdaRoleMgmt"
+        }
+      }
+      steps {
+        script {
+          def accountNumber = tdr.getAccountNumberFromStage(env.MANAGEMENT_ACCOUNT)
+          sh "python3 /deploy_lambda_from_s3.py ${accountNumber} mgmt tdr-notifications-mgmt tdr-backend-code-mgmt ${params.TO_DEPLOY}/notifications.jar"
+        }
+      }
+    }
+    stage("Update release branch") {
+      steps {
+        script {
+          def releaseBranch = "release-mgmt"
+
+          sh "git branch -f ${releaseBranch} HEAD"
+          sshagent(['github-jenkins']) {
+            sh("git push -f origin ${releaseBranch}")
+          }
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile-test
+++ b/Jenkinsfile-test
@@ -3,7 +3,7 @@ library("tdr-jenkinslib")
 lambdaTests(
   // Hard-code stage, since it is arbitrary in the lambdaTests
   // function, which publishes the code to the management account
-  stage: "mgmt",
+  stage: "intg",
   libraryName: "notifications",
   deployJobName: "TDR Notifications Deploy"
 )


### PR DESCRIPTION
- Create separate deployments for management and other environments
- Add the build steps normally in the test job
- Hard code the lambda name
- Put the deploy job back
- Default the test file to the intg environment
