### PR TITLE
Temporarily allow Slack notifications for exports on intg

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -146,23 +146,18 @@ object EventMessages {
     }
 
     override def slack(incomingEvent: ExportStatusEvent, context: Unit): Option[SlackMessage] = {
-      if(incomingEvent.environment != "intg" || !incomingEvent.success) {
+      val exportInfoMessage = constructExportInfoMessage(incomingEvent)
 
-        val exportInfoMessage = constructExportInfoMessage(incomingEvent)
-
-        val message: String = if (incomingEvent.success) {
-          s":white_check_mark: Export *success* on *${incomingEvent.environment}!* \n" +
-            s"*Consignment ID:* ${incomingEvent.consignmentId}" +
-            s"$exportInfoMessage"
-        } else {
-          s":x: Export *failure* on *${incomingEvent.environment}!* \n" +
+      val message: String = if (incomingEvent.success) {
+        s":white_check_mark: Export *success* on *${incomingEvent.environment}!* \n" +
           s"*Consignment ID:* ${incomingEvent.consignmentId}" +
           s"$exportInfoMessage"
-        }
-        SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", message)))).some
       } else {
-        Option.empty
+        s":x: Export *failure* on *${incomingEvent.environment}!* \n" +
+        s"*Consignment ID:* ${incomingEvent.consignmentId}" +
+        s"$exportInfoMessage"
       }
+      SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", message)))).some
     }
 
     private def constructExportInfoMessage(incomingEvent: ExportStatusEvent): String = {

--- a/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
@@ -8,7 +8,7 @@ import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.{Expor
 class ExportIntegrationSpec extends LambdaIntegrationSpec {
   override lazy val events: TableFor5[String, String, Option[String], Option[String], () => ()] = Table(
     ("description", "input", "emailBody", "slackBody", "stubContext"),
-    ("a successful export event on intg", exportStatusEventInputText(exportStatus1), None, None, () => ()),
+    ("a successful export event on intg", exportStatusEventInputText(exportStatus1), None, Some(expectedSlackMessage(exportStatus1)), () => ()),
     ("a failed export event on intg", exportStatusEventInputText(exportStatus2), None, Some(expectedSlackMessage(exportStatus2)), () => ()),
     ("a successful export event on staging", exportStatusEventInputText(exportStatus3), None, Some(expectedSlackMessage(exportStatus3)), () => ()),
     ("a failed export event on staging", exportStatusEventInputText(exportStatus4), None, Some(expectedSlackMessage(exportStatus4)), () => ()),


### PR DESCRIPTION
We don't normally enable these because they're very noisy and don't give much useful information, but they'll be helpful for the show and tell demonstation tomorrow.