### PR TITLE
Revert "Temporarily allow Slack notifications for exports on intg"

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -146,18 +146,23 @@ object EventMessages {
     }
 
     override def slack(incomingEvent: ExportStatusEvent, context: Unit): Option[SlackMessage] = {
-      val exportInfoMessage = constructExportInfoMessage(incomingEvent)
+      if(incomingEvent.environment != "intg" || !incomingEvent.success) {
 
-      val message: String = if (incomingEvent.success) {
-        s":white_check_mark: Export *success* on *${incomingEvent.environment}!* \n" +
+        val exportInfoMessage = constructExportInfoMessage(incomingEvent)
+
+        val message: String = if (incomingEvent.success) {
+          s":white_check_mark: Export *success* on *${incomingEvent.environment}!* \n" +
+            s"*Consignment ID:* ${incomingEvent.consignmentId}" +
+            s"$exportInfoMessage"
+        } else {
+          s":x: Export *failure* on *${incomingEvent.environment}!* \n" +
           s"*Consignment ID:* ${incomingEvent.consignmentId}" +
           s"$exportInfoMessage"
+        }
+        SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", message)))).some
       } else {
-        s":x: Export *failure* on *${incomingEvent.environment}!* \n" +
-        s"*Consignment ID:* ${incomingEvent.consignmentId}" +
-        s"$exportInfoMessage"
+        Option.empty
       }
-      SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", message)))).some
     }
 
     private def constructExportInfoMessage(incomingEvent: ExportStatusEvent): String = {

--- a/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
@@ -8,7 +8,7 @@ import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.{Expor
 class ExportIntegrationSpec extends LambdaIntegrationSpec {
   override lazy val events: TableFor5[String, String, Option[String], Option[String], () => ()] = Table(
     ("description", "input", "emailBody", "slackBody", "stubContext"),
-    ("a successful export event on intg", exportStatusEventInputText(exportStatus1), None, Some(expectedSlackMessage(exportStatus1)), () => ()),
+    ("a successful export event on intg", exportStatusEventInputText(exportStatus1), None, None, () => ()),
     ("a failed export event on intg", exportStatusEventInputText(exportStatus2), None, Some(expectedSlackMessage(exportStatus2)), () => ()),
     ("a successful export event on staging", exportStatusEventInputText(exportStatus3), None, Some(expectedSlackMessage(exportStatus3)), () => ()),
     ("a failed export event on staging", exportStatusEventInputText(exportStatus4), None, Some(expectedSlackMessage(exportStatus4)), () => ()),


### PR DESCRIPTION
This reverts commit 929f1b13ac95a0d4b5c5c9656692a3c770bcea19.

It was a temporary commit to allow us to demo export notifications for a show and tell.

Marking the PR as draft until it's ready to merge.