### PR TITLE
Add notification for disk alert messages

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
@@ -1,11 +1,11 @@
 package uk.gov.nationalarchives.notifications
 
 import java.io.{InputStream, OutputStream}
-
 import cats.effect._
 import cats.implicits.toFlatMapOps
 import io.circe.parser.decode
 import messages.Messages._
+import uk.gov.nationalarchives.notifications.decoders.DiskSpaceAlarmDecoder.DiskSpaceAlarmEvent
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportStatusEvent
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
 import uk.gov.nationalarchives.notifications.decoders.SSMMaintenanceDecoder.SSMMaintenanceEvent
@@ -18,9 +18,10 @@ import scala.io.Source
 class Lambda {
   def process(input: InputStream, output: OutputStream): String =
     IO.fromEither(decode[IncomingEvent](Source.fromInputStream(input).mkString).map {
-    case maintenance : SSMMaintenanceEvent => sendMessages(maintenance)
-    case scan: ScanEvent => sendMessages(scan)
-    case exportStatus: ExportStatusEvent => sendMessages(exportStatus)
-    case keycloakEvent: KeycloakEvent => sendMessages(keycloakEvent)
-  }).flatten.unsafeRunSync()
-}
+      case maintenance: SSMMaintenanceEvent => sendMessages(maintenance)
+      case scan: ScanEvent => sendMessages(scan)
+      case exportStatus: ExportStatusEvent => sendMessages(exportStatus)
+      case keycloakEvent: KeycloakEvent => sendMessages(keycloakEvent)
+      case diskSpaceAlarmEvent: DiskSpaceAlarmEvent => sendMessages(diskSpaceAlarmEvent)
+    }).flatten.unsafeRunSync()
+  }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/LambdaRunner.scala
@@ -52,6 +52,20 @@ object LambdaRunner extends App {
          |
          |""".stripMargin
 
+  val diskSpaceFullMessage =
+    s"""
+       |{
+       |    "Records": [
+       |        {
+       |            "Sns": {
+       |                "Message": "{\\"AlarmName\\":\\"tdr-jenkins-disk-space-alarm-mgmt\\",\\"NewStateValue\\":\\"OK\\",\\"Trigger\\":{\\"Dimensions\\":[{\\"value\\":\\"Jenkins\\",\\"name\\":\\"server_name\\"}],\\"Threshold\\":20.0}}"
+       |            }
+       |        }
+       |    ]
+       |}
+       |
+       |""".stripMargin
+
   val inputStream = new ByteArrayInputStream(ecrScanMessage.getBytes)
 
   // The Lambda does not use the output stream, so it's safe to set it to null

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/DiskSpaceAlarmDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/DiskSpaceAlarmDecoder.scala
@@ -1,0 +1,19 @@
+package uk.gov.nationalarchives.notifications.decoders
+
+import io.circe.{Decoder, HCursor}
+import io.circe.generic.auto._
+import uk.gov.nationalarchives.notifications.decoders.IncomingEvent.{Record, parseSNSMessage}
+
+object DiskSpaceAlarmDecoder {
+
+  case class AlarmDimension(name: String, `value`: String)
+  case class AlarmTrigger(Dimensions: List[AlarmDimension], Threshold: Int)
+  case class DiskSpaceAlarmEvent(NewStateValue: String, AlarmName: String, Trigger: AlarmTrigger) extends IncomingEvent
+
+  val decodeDiskSpaceAlertEvent: Decoder[IncomingEvent] = (c: HCursor) => for {
+    messages <- c.downField("Records").as[List[Record]]
+    json <- parseSNSMessage(messages.head.Sns.Message)
+    status <- json.as[DiskSpaceAlarmEvent]
+  } yield status
+
+}

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/DiskSpaceAlarmDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/DiskSpaceAlarmDecoder.scala
@@ -1,19 +1,8 @@
 package uk.gov.nationalarchives.notifications.decoders
 
-import io.circe.{Decoder, HCursor}
-import io.circe.generic.auto._
-import uk.gov.nationalarchives.notifications.decoders.IncomingEvent.{Record, parseSNSMessage}
-
 object DiskSpaceAlarmDecoder {
 
   case class AlarmDimension(name: String, `value`: String)
   case class AlarmTrigger(Dimensions: List[AlarmDimension], Threshold: Int)
   case class DiskSpaceAlarmEvent(NewStateValue: String, AlarmName: String, Trigger: AlarmTrigger) extends IncomingEvent
-
-  val decodeDiskSpaceAlertEvent: Decoder[IncomingEvent] = (c: HCursor) => for {
-    messages <- c.downField("Records").as[List[Record]]
-    json <- parseSNSMessage(messages.head.Sns.Message)
-    status <- json.as[DiskSpaceAlarmEvent]
-  } yield status
-
 }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ExportStatusDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ExportStatusDecoder.scala
@@ -2,10 +2,6 @@ package uk.gov.nationalarchives.notifications.decoders
 
 import java.util.UUID
 
-import io.circe.generic.auto._
-import io.circe.{Decoder, HCursor}
-import uk.gov.nationalarchives.notifications.decoders.IncomingEvent.{Record, parseSNSMessage}
-
 object ExportStatusDecoder {
   case class ExportSuccessDetails(userId: UUID, consignmentReference: String, transferringBodyCode: String)
   case class ExportStatusEvent(
@@ -14,9 +10,4 @@ object ExportStatusDecoder {
                                 environment: String,
                                 successDetails: Option[ExportSuccessDetails],
                                 failureCause: Option[String]) extends IncomingEvent
-  val decodeExportStatusEvent: Decoder[IncomingEvent] = (c: HCursor) => for {
-    messages <- c.downField("Records").as[List[Record]]
-    json <- parseSNSMessage(messages.head.Sns.Message)
-    status <- json.as[ExportStatusEvent]
-  } yield status
 }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
@@ -2,19 +2,26 @@ package uk.gov.nationalarchives.notifications.decoders
 
 import io.circe.CursorOp.DownField
 import io.circe.parser.parse
-import io.circe.{Decoder, DecodingFailure, Json}
+import io.circe.generic.auto._
+import io.circe.{Decoder, DecodingFailure, HCursor, Json}
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.decodeScanEvent
 import uk.gov.nationalarchives.notifications.decoders.SSMMaintenanceDecoder.decodeMaintenanceEvent
-import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.decodeExportStatusEvent
-import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.decodeKeycloakEvent
-import uk.gov.nationalarchives.notifications.decoders.DiskSpaceAlarmDecoder.decodeDiskSpaceAlertEvent
+import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportStatusEvent
+import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
+import uk.gov.nationalarchives.notifications.decoders.DiskSpaceAlarmDecoder.DiskSpaceAlarmEvent
 
 trait IncomingEvent {
 }
 
 object IncomingEvent {
-  implicit val allDecoders: Decoder[IncomingEvent] = decodeScanEvent or decodeMaintenanceEvent or decodeExportStatusEvent or
-    decodeKeycloakEvent or decodeDiskSpaceAlertEvent
+  implicit val allDecoders: Decoder[IncomingEvent] = decodeScanEvent or decodeMaintenanceEvent or decodeEvent[ExportStatusEvent] or
+    decodeEvent[KeycloakEvent] or decodeEvent[DiskSpaceAlarmEvent]
+
+  def decodeEvent[T <: IncomingEvent]()(implicit decoder: Decoder[T]): Decoder[IncomingEvent] = (c: HCursor) => for {
+    messages <- c.downField("Records").as[List[Record]]
+    json <- parseSNSMessage(messages.head.Sns.Message)
+    event <- json.as[T]
+  } yield event
 
   def parseSNSMessage(snsMessage: String): Either[DecodingFailure, Json] = {
     parse(snsMessage)

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
@@ -7,13 +7,14 @@ import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.decodeScanEven
 import uk.gov.nationalarchives.notifications.decoders.SSMMaintenanceDecoder.decodeMaintenanceEvent
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.decodeExportStatusEvent
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.decodeKeycloakEvent
+import uk.gov.nationalarchives.notifications.decoders.DiskSpaceAlarmDecoder.decodeDiskSpaceAlertEvent
 
 trait IncomingEvent {
 }
 
 object IncomingEvent {
   implicit val allDecoders: Decoder[IncomingEvent] = decodeScanEvent or decodeMaintenanceEvent or decodeExportStatusEvent or
-    decodeKeycloakEvent
+    decodeKeycloakEvent or decodeDiskSpaceAlertEvent
 
   def parseSNSMessage(snsMessage: String): Either[DecodingFailure, Json] = {
     parse(snsMessage)

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/KeycloakEventDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/KeycloakEventDecoder.scala
@@ -1,15 +1,5 @@
 package uk.gov.nationalarchives.notifications.decoders
 
-import io.circe.generic.auto._
-import io.circe.{Decoder, HCursor}
-import uk.gov.nationalarchives.notifications.decoders.IncomingEvent.{Record, parseSNSMessage}
-
 object KeycloakEventDecoder {
   case class KeycloakEvent(tdrEnv: String, message: String) extends IncomingEvent
-
-  val decodeKeycloakEvent: Decoder[IncomingEvent] = (c: HCursor) => for {
-    messages <- c.downField("Records").as[List[Record]]
-    json <- parseSNSMessage(messages.head.Sns.Message)
-    event <- json.as[KeycloakEvent]
-  } yield event
 }

--- a/src/test/scala/uk/gov/nationalarchives/notifications/DiskSpaceAlarmIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/DiskSpaceAlarmIntegrationSpec.scala
@@ -1,0 +1,58 @@
+package uk.gov.nationalarchives.notifications
+
+import cats.implicits._
+import org.scalatest.prop.TableFor5
+
+class DiskSpaceAlarmIntegrationSpec extends LambdaIntegrationSpec {
+
+  private def event(status: String, serverName: String, threshold: Int) = {
+    s"""
+       |{
+       |    "Records": [
+       |        {
+       |            "Sns": {
+       |                "Message": "{\\"AlarmName\\":\\"tdr-jenkins-disk-space-alarm-mgmt\\",\\"NewStateValue\\":\\"$status\\",\\"Trigger\\":{\\"Dimensions\\":[{\\"value\\":\\"$serverName\\",\\"name\\":\\"server_name\\"}],\\"Threshold\\":$threshold}}"
+       |            }
+       |        }
+       |    ]
+       |}
+       |
+       |""".stripMargin
+  }
+
+  private def slackMessage(status: String, serverName: String, threshold: Int): Option[String] = {
+    if (status == "ALARM") {
+      s"""{
+         |  "blocks" : [ {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : ":warning: $serverName disk space is over $threshold percent"
+         |    }
+         |  } ]
+         |}""".stripMargin.some
+    } else if(status == "OK") {
+      s"""{
+         |  "blocks" : [ {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : ":white_check_mark: $serverName disk space is now below $threshold percent"
+         |    }
+         |  } ]
+         |}""".stripMargin.some
+    } else {
+      None
+    }
+  }
+
+  override def events: TableFor5[String, String, Option[String], Option[String], () => Unit] = Table(
+    ("description", "input", "emailBody", "slackBody", "stubContext"),
+    ("Alarm OK for server Jenkins with threshold 20", event("OK", "Jenkins", 20), None, slackMessage("OK", "Jenkins", 20), () => ()),
+    ("Alarm OK for server Jenkins with threshold 70", event("OK", "Jenkins", 70), None, slackMessage("OK", "Jenkins", 70), () => ()),
+    ("Alarm OK for server JenkinsProd with threshold 70", event("OK", "JenkinsProd", 70), None, slackMessage("OK", "JenkinsProd", 70), () => ()),
+    ("Alarm ALARM for server Jenkins with threshold 20", event("ALARM", "Jenkins", 20), None, slackMessage("ALARM", "Jenkins", 20), () => ()),
+    ("Alarm ALARM for server Jenkins with threshold 70", event("ALARM", "Jenkins", 70), None, slackMessage("ALARM", "Jenkins", 70), () => ()),
+    ("Alarm ALARM for server JenkinsProd with threshold 70", event("ALARM", "JenkinsProd", 70), None, slackMessage("ALARM", "JenkinsProd", 70), () => ())
+  )
+}


### PR DESCRIPTION
There is a cloudwatch alarm set up which monitors the disk usage of the
Jenkins instances.

When the disk usage goes over a threshold or when it goes below the
threshold, a message is sent to slack.

The message contains the server (Jenkins or JenkinsProd), the threshold
and the either a tick or a warning symbol depending on where it's ALARM
or OK.
