### PR TITLE
Create a separate alert message for no data points.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/DiskSpaceAlarmDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/DiskSpaceAlarmDecoder.scala
@@ -4,5 +4,5 @@ object DiskSpaceAlarmDecoder {
 
   case class AlarmDimension(name: String, `value`: String)
   case class AlarmTrigger(Dimensions: List[AlarmDimension], Threshold: Int)
-  case class DiskSpaceAlarmEvent(NewStateValue: String, AlarmName: String, Trigger: AlarmTrigger) extends IncomingEvent
+  case class DiskSpaceAlarmEvent(NewStateValue: String, AlarmName: String, Trigger: AlarmTrigger, NewStateReason: String) extends IncomingEvent
 }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -204,9 +204,16 @@ object EventMessages {
           val text = if(incomingEvent.NewStateValue == "OK") {
             s":white_check_mark: $serverName disk space is now below ${trigger.Threshold} percent"
           } else {
-            s":warning: $serverName disk space is over ${trigger.Threshold} percent"
+            if(incomingEvent.NewStateReason.contains("no datapoints were received")) {
+              s":warning: $serverName is not sending disk space data to Cloudwatch. This is most likely because Jenkins is restarting."
+            } else {
+              s":warning: $serverName disk space is over ${trigger.Threshold} percent"
+            }
           }
-          SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", text))))
+          SlackMessage(List(
+            SlackBlock("section", SlackText("mrkdwn", text)),
+            SlackBlock("section", SlackText("mrkdwn", "See https://grafana.tdr-management.nationalarchives.gov.uk/d/eDVRAnI7z/jenkins-disk-space to see the data")))
+          )
         })
       } else {
         Option.empty

--- a/src/test/scala/uk/gov/nationalarchives/notifications/DiskSpaceAlarmIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/DiskSpaceAlarmIntegrationSpec.scala
@@ -5,13 +5,13 @@ import org.scalatest.prop.TableFor5
 
 class DiskSpaceAlarmIntegrationSpec extends LambdaIntegrationSpec {
 
-  private def event(status: String, serverName: String, threshold: Int) = {
+  private def event(status: String, serverName: String, threshold: Int, newStateReason: String = "") = {
     s"""
        |{
        |    "Records": [
        |        {
        |            "Sns": {
-       |                "Message": "{\\"AlarmName\\":\\"tdr-jenkins-disk-space-alarm-mgmt\\",\\"NewStateValue\\":\\"$status\\",\\"Trigger\\":{\\"Dimensions\\":[{\\"value\\":\\"$serverName\\",\\"name\\":\\"server_name\\"}],\\"Threshold\\":$threshold}}"
+       |                "Message": "{\\"AlarmName\\":\\"tdr-jenkins-disk-space-alarm-mgmt\\",\\"NewStateReason\\": \\"$newStateReason\\",\\"NewStateValue\\":\\"$status\\",\\"Trigger\\":{\\"Dimensions\\":[{\\"value\\":\\"$serverName\\",\\"name\\":\\"server_name\\"}],\\"Threshold\\":$threshold}}"
        |            }
        |        }
        |    ]
@@ -20,17 +20,46 @@ class DiskSpaceAlarmIntegrationSpec extends LambdaIntegrationSpec {
        |""".stripMargin
   }
 
-  private def slackMessage(status: String, serverName: String, threshold: Int): Option[String] = {
+  private def slackMessage(status: String, serverName: String, threshold: Int, newStateReason: String = ""): Option[String] = {
     if (status == "ALARM") {
-      s"""{
-         |  "blocks" : [ {
-         |    "type" : "section",
-         |    "text" : {
-         |      "type" : "mrkdwn",
-         |      "text" : ":warning: $serverName disk space is over $threshold percent"
-         |    }
-         |  } ]
-         |}""".stripMargin.some
+      if(newStateReason != "") {
+        s"""{
+           |  "blocks" : [ {
+           |    "type" : "section",
+           |    "text" : {
+           |      "type" : "mrkdwn",
+           |      "text" : ":warning: $serverName is not sending disk space data to Cloudwatch. This is most likely because Jenkins is restarting."
+           |    }
+           |  },
+           |  {
+           |			"type": "section",
+           |			"text": {
+           |				"type": "mrkdwn",
+           |				"text": "See https://grafana.tdr-management.nationalarchives.gov.uk/d/eDVRAnI7z/jenkins-disk-space to see the data"
+           |			}
+           |	}
+           |  ]
+           |}""".stripMargin.some
+      } else {
+        s"""{
+           |  "blocks" : [ {
+           |    "type" : "section",
+           |    "text" : {
+           |      "type" : "mrkdwn",
+           |      "text" : ":warning: $serverName disk space is over $threshold percent"
+           |    }
+           |  },
+           |  {
+           |	  "type": "section",
+           |			"text": {
+           |				"type": "mrkdwn",
+           |				"text": "See https://grafana.tdr-management.nationalarchives.gov.uk/d/eDVRAnI7z/jenkins-disk-space to see the data"
+           |			}
+           |	}
+           |  ]
+           |}""".stripMargin.some
+      }
+
     } else if(status == "OK") {
       s"""{
          |  "blocks" : [ {
@@ -39,7 +68,15 @@ class DiskSpaceAlarmIntegrationSpec extends LambdaIntegrationSpec {
          |      "type" : "mrkdwn",
          |      "text" : ":white_check_mark: $serverName disk space is now below $threshold percent"
          |    }
-         |  } ]
+         |  },
+         |  {
+         |	  "type": "section",
+         |			"text": {
+         |				"type": "mrkdwn",
+         |				"text": "See https://grafana.tdr-management.nationalarchives.gov.uk/d/eDVRAnI7z/jenkins-disk-space to see the data"
+         |			}
+         |	}
+         |  ]
          |}""".stripMargin.some
     } else {
       None
@@ -53,6 +90,8 @@ class DiskSpaceAlarmIntegrationSpec extends LambdaIntegrationSpec {
     ("Alarm OK for server JenkinsProd with threshold 70", event("OK", "JenkinsProd", 70), None, slackMessage("OK", "JenkinsProd", 70), () => ()),
     ("Alarm ALARM for server Jenkins with threshold 20", event("ALARM", "Jenkins", 20), None, slackMessage("ALARM", "Jenkins", 20), () => ()),
     ("Alarm ALARM for server Jenkins with threshold 70", event("ALARM", "Jenkins", 70), None, slackMessage("ALARM", "Jenkins", 70), () => ()),
-    ("Alarm ALARM for server JenkinsProd with threshold 70", event("ALARM", "JenkinsProd", 70), None, slackMessage("ALARM", "JenkinsProd", 70), () => ())
+    ("Alarm ALARM for server JenkinsProd with threshold 70", event("ALARM", "JenkinsProd", 70), None, slackMessage("ALARM", "JenkinsProd", 70), () => ()),
+    ("Alarm ALARM for server JenkinsProd with no data points", event("ALARM", "JenkinsProd", 70, "no datapoints were received"), None, slackMessage("ALARM", "JenkinsProd", 70, "no datapoints were received"), () => ()),
+    ("Alarm ALARM for server Jenkins with no data points", event("ALARM", "Jenkins", 70, "no datapoints were received"), None, slackMessage("ALARM", "Jenkins", 70, "no datapoints were received"), () => ())
   )
 }


### PR DESCRIPTION
The cloudwatch alarm for Jenkins is set to show an error if it stops
receiving data from the Jenkins Cloudwatch agent. This is good in that
we get alerted if there is a problem with the agent but it's confusing
in that it says that the disk space is above 70% when it isn't.
I've changed this to put in a more sensible message if the problem is
missing data points. The only way is to check for a string in the reason
field but that's unlikely to change so we should be ok.
