### PR TITLE
dependency updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,13 +25,13 @@ lazy val root = (project in file("."))
     )
   )
 
-fork in Test := true
-javaOptions in Test += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
+(Test / fork) := true
+(Test / javaOptions) += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
 
 resolvers += "TDR Releases" at "s3://tdr-releases-mgmt"
-assemblyJarName in assembly := "notifications.jar"
+(assembly / assemblyJarName) := "notifications.jar"
 
-assemblyMergeStrategy in assembly := {
+(assembly / assemblyMergeStrategy) := {
   case PathList("META-INF", xs@_*) => MergeStrategy.discard
   case _ => MergeStrategy.first
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-ThisBuild / scalaVersion     := "2.13.3"
+ThisBuild / scalaVersion     := "2.13.8"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.example"
 ThisBuild / organizationName := "example"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   private val circeVersion = "0.13.0"
   private val sttpClient3Version = "3.3.15"
-  private val elasticMqVersion = "1.1.1"
+  private val elasticMqVersion = "1.3.6"
 
   lazy val sttp = "com.softwaremill.sttp.client3" %% "async-http-client-backend-cats" % sttpClient3Version
   lazy val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % sttpClient3Version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   lazy val typesafe = "com.typesafe" % "config" % "1.4.0"
   lazy val scalaTags = "com.lihaoyi" %% "scalatags" % "0.8.6"
   lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.21"
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.2"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.11"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "2.27.2"
   lazy val typesafeConfig = "com.typesafe" % "config" % "1.4.1"
   lazy val typeSafeLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  private val circeVersion = "0.13.0"
+  private val circeVersion = "0.14.1"
   private val sttpClient3Version = "3.3.15"
   private val elasticMqVersion = "1.3.6"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
-  lazy val typesafe = "com.typesafe" % "config" % "1.4.0"
+  lazy val typesafe = "com.typesafe" % "config" % "1.4.2"
   lazy val scalaTags = "com.lihaoyi" %% "scalatags" % "0.8.6"
   lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.21"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.11"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.21.0")


### PR DESCRIPTION
- Update sbt-assembly to 1.2.0
- Update typesafe:config to 1.4.2
- Update circe-core, circe-generic, ... to 0.14.1
- Update elasticmq-rest-sqs, ... to 1.3.6
- Update scala-library to 2.13.8
- Applied Scalafix rule(s) https://gist.githubusercontent.com/eed3si9n/57e83f5330592d968ce49f0d5030d4d5/raw/7f576f16a90e432baa49911c9a66204c354947bb/Sbt0_13BuildSyntax.scala
- Update sbt to 1.6.2
- Update scalatest to 3.2.11
