### PR TITLE
Send most messages to da-tdr-notifications.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,7 +1,8 @@
 slack {
   webhook {
-    url = ${SLACK_WEBHOOK} #da-tdr
+    url = ${SLACK_WEBHOOK} #da-tdr-notifications
     judgment_url = ${SLACK_JUDGMENT_WEBHOOK} #da-tdr-prod-exports-judgments
+    tdr_url = ${SLACK_TDR_WEBHOOK} #da-tdr
   }
 }
 ses {

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,7 +1,8 @@
 slack {
   webhook {
     url = "aHR0cDovL2xvY2FsaG9zdDo5MDAyL3dlYmhvb2s=" # Base 64 decodes to this value http://localhost:9002/webhook
-    judgment_url = "aHR0cDovL2xvY2FsaG9zdDo5MDAyL3dlYmhvb2s=" # Base 64 decodes to this value http://localhost:9002/webhook
+    judgment_url = "aHR0cDovL2xvY2FsaG9zdDo5MDAyL3dlYmhvb2stanVkZ21lbnQ=" # Base 64 decodes to this value http://localhost:9002/webhook-judgment
+    tdr_url = "aHR0cDovL2xvY2FsaG9zdDo5MDAyL3dlYmhvb2stdGRy" # Base 64 decodes to this value http://localhost:9002/webhook-tdr
   }
 }
 ses {

--- a/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
@@ -1,24 +1,24 @@
 package uk.gov.nationalarchives.notifications
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import org.scalatest.prop.TableFor6
+import org.scalatest.prop.TableFor7
 import uk.gov.nationalarchives.notifications.EcrScanIntegrationSpec.scanEventInputText
-import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportSuccessDetails
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.{ScanDetail, ScanEvent, ScanFindingCounts}
 
 import scala.io.Source
 
 class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
 
-  override lazy val events: TableFor6[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], () => Unit] = Table(
-    ("description", "input", "emailBody", "slackBody", "sqsMessage", "stubContext"),
+  override lazy val events: TableFor7[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], () => Unit, String] = Table(
+    ("description", "input", "emailBody", "slackBody", "sqsMessage", "stubContext", "slackUrl"),
     (
       "an ECR scan of 'latest' with a mix of severities",
       scanEventInputText(mixedSeverityEvent),
       Some(expectedEmailBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 4, 1))),
       Some(expectedSlackBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 4, 1))),
       None,
-      stubEcrApiResponse(mixedSeverityEvent.detail.imageDigest, mixedSeverityFindings)
+      stubEcrApiResponse(mixedSeverityEvent.detail.imageDigest, mixedSeverityFindings),
+      "/webhook"
     ),
     (
       "an ECR scan of 'latest' with only low severity vulnerabilities",
@@ -26,7 +26,8 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       Some(expectedEmailBody(lowSeverityEvent, ExpectedFindings(0, 0, 0, 1, 0))),
       Some(expectedSlackBody(lowSeverityEvent, ExpectedFindings(0, 0, 0, 1, 0))),
       None,
-      stubEcrApiResponse(lowSeverityEvent.detail.imageDigest, lowSeverityFindings)
+      stubEcrApiResponse(lowSeverityEvent.detail.imageDigest, lowSeverityFindings),
+      "/webhook"
     ),
     (
       "an ECR scan of 'latest' with only undefined severity vulnerabilities",
@@ -34,7 +35,8 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       Some(expectedEmailBody(undefinedSeverityEvent, ExpectedFindings(0, 0, 0, 0, 1))),
       Some(expectedSlackBody(undefinedSeverityEvent, ExpectedFindings(0, 0, 0, 0, 1))),
       None,
-      stubEcrApiResponse(undefinedSeverityEvent.detail.imageDigest, undefinedFindings)
+      stubEcrApiResponse(undefinedSeverityEvent.detail.imageDigest, undefinedFindings),
+      "/webhook"
     ),
     (
       "an ECR scan of 'latest' with only informational vulnerabilities",
@@ -42,7 +44,8 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       None,
       None,
       None,
-      stubEcrApiResponse(informationalEvent.detail.imageDigest, informationalFindings)
+      stubEcrApiResponse(informationalEvent.detail.imageDigest, informationalFindings),
+      "/webhook"
     ),
     (
       "an ECR scan of 'latest' with no results",
@@ -50,7 +53,8 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       None,
       None,
       None,
-      stubEcrApiResponse(noVulnerabilitiesEvent.detail.imageDigest, noFindings)
+      stubEcrApiResponse(noVulnerabilitiesEvent.detail.imageDigest, noFindings),
+      "/webhook"
     ),
     (
       "an ECR scan of an image with a non-deployment tag",
@@ -58,7 +62,8 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       None,
       None,
       None,
-      stubEcrApiResponse(otherTagEvent.detail.imageDigest, lowSeverityFindings)
+      stubEcrApiResponse(otherTagEvent.detail.imageDigest, lowSeverityFindings),
+      "/webhook"
     ),
     (
       "an ECR scan of 'intg' with no results",
@@ -66,7 +71,8 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       None,
       None,
       None,
-      stubEcrApiResponse(intgTagEmptyEvent.detail.imageDigest, noFindings)
+      stubEcrApiResponse(intgTagEmptyEvent.detail.imageDigest, noFindings),
+      "/webhook"
     ),
     (
       "an ECR scan which only contains a muted vulnerability",
@@ -74,7 +80,8 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       None,
       None,
       None,
-      stubEcrApiResponse(lowSeverityEvent.detail.imageDigest, findingsWithOnlyMutedVulnerability)
+      stubEcrApiResponse(lowSeverityEvent.detail.imageDigest, findingsWithOnlyMutedVulnerability),
+      "/webhook"
     ),
     (
       "an ECR scan with a mix of muted and non-muted vulnerabilities",
@@ -82,7 +89,8 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       Some(expectedEmailBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 3, 0))),
       Some(expectedSlackBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 3, 0))),
       None,
-      stubEcrApiResponse(mixedSeverityEvent.detail.imageDigest, findingsIncludingMutedVulnerability)
+      stubEcrApiResponse(mixedSeverityEvent.detail.imageDigest, findingsIncludingMutedVulnerability),
+      "/webhook"
     ),
   )
 

--- a/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
@@ -1,56 +1,59 @@
 package uk.gov.nationalarchives.notifications
 
-import java.util.UUID
-
-import org.scalatest.prop.TableFor6
+import org.scalatest.prop.TableFor7
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.{ExportStatusEvent, ExportSuccessDetails}
+
+import java.util.UUID
 
 class ExportIntegrationSpec extends LambdaIntegrationSpec {
 
-  override lazy val events: TableFor6[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], () => Unit] = Table(
-    ("description", "input", "emailBody", "slackBody", "sqsMessage", "stubContext"),
+  override lazy val events: TableFor7[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], () => Unit, String] = Table(
+    ("description", "input", "emailBody", "slackBody", "sqsMessage", "stubContext", "slackUrl"),
     ("a successful standard export event on intg",
-      exportStatusEventInputText(exportStatus1), None, None, None, () => ()),
+      exportStatusEventInputText(exportStatus1), None, None, None, () => (), "/webhook"),
     ("a successful judgment export event on intg",
-      exportStatusEventInputText(exportStatus2), None, None, expectedSqsMessage(exportStatus2), () => ()),
+      exportStatusEventInputText(exportStatus2), None, None, expectedSqsMessage(exportStatus2), () => (), "/webhook"),
     ("a successful judgment export event using a mock transferring body on intg",
-      exportStatusEventInputText(exportStatus3), None, None, None, () => ()),
+      exportStatusEventInputText(exportStatus3), None, None, None, () => (), "/webhook"),
     ("a failed export event on intg",
-      exportStatusEventInputText(exportStatus4), None, Some(expectedSlackMessage(exportStatus4)), None, () => ()),
+      exportStatusEventInputText(exportStatus4), None, Some(expectedSlackMessage(exportStatus4)), None, () => (), "/webhook"),
     ("a successful standard export event on staging",
-      exportStatusEventInputText(exportStatus5), None, Some(expectedSlackMessage(exportStatus5)), None, () => ()),
+      exportStatusEventInputText(exportStatus5), None, Some(expectedSlackMessage(exportStatus5)), None, () => (), "/webhook"),
     ("a successful judgment export event on staging",
-      exportStatusEventInputText(exportStatus6), None, Some(expectedSlackMessage(exportStatus6)), expectedSqsMessage(exportStatus6), () => ()),
+      exportStatusEventInputText(exportStatus6), None, Some(expectedSlackMessage(exportStatus6)), expectedSqsMessage(exportStatus6), () => (), "/webhook"),
     ("a successful judgment export event using a mock transferring body on staging",
-      exportStatusEventInputText(exportStatus7), None, Some(expectedSlackMessage(exportStatus7)), None, () => ()),
+      exportStatusEventInputText(exportStatus7), None, Some(expectedSlackMessage(exportStatus7)), None, () => (), "/webhook"),
     ("a failed export event on staging",
-      exportStatusEventInputText(exportStatus8), None, Some(expectedSlackMessage(exportStatus8)), None, () => ()),
+      exportStatusEventInputText(exportStatus8), None, Some(expectedSlackMessage(exportStatus8)), None, () => (), "/webhook"),
     ("a failed export on intg with no error details",
-      exportStatusEventInputText(exportStatus9), None, Some(expectedSlackMessage(exportStatus9)), None, () => ()),
+      exportStatusEventInputText(exportStatus9), None, Some(expectedSlackMessage(exportStatus9)), None, () => (), "/webhook"),
     ("a failed export on staging with no error details",
-      exportStatusEventInputText(exportStatus10), None, Some(expectedSlackMessage(exportStatus10)), None, () => ()),
+      exportStatusEventInputText(exportStatus10), None, Some(expectedSlackMessage(exportStatus10)), None, () => (), "/webhook"),
     ("a successful export event on prod",
-      exportStatusEventInputText(exportStatus11), None, Some(expectedSlackMessage(exportStatus11)), None, () => ()),
+      exportStatusEventInputText(exportStatus11), None, Some(expectedSlackMessage(exportStatus11)), None, () => (), "/webhook"),
     ("a failed export event on prod",
-      exportStatusEventInputText(exportStatus12), None, Some(expectedSlackMessage(exportStatus12)), None, () => ()),
+      exportStatusEventInputText(exportStatus12), None, Some(expectedSlackMessage(exportStatus12)), None, () => (), "/webhook"),
+    ("a successful judgment export on prod",
+    exportStatusEventInputText(exportStatus13), None, Some(expectedSlackMessage(exportStatus13)), expectedSqsMessage(exportStatus13), () => (), "/webhook-judgment")
   )
 
   private lazy val successDetailsStandard = ExportSuccessDetails(UUID.randomUUID(), "consignmentRef1", "tb-body1", "standard", "export-bucket")
   private lazy val successDetailsJudgment = ExportSuccessDetails(UUID.randomUUID(), "consignmentRef1", "tb-body1", "judgment", "export-bucket")
   private lazy val successDetailsJudgmentMockBody = ExportSuccessDetails(UUID.randomUUID(), "consignmentRef1", "MOCK1 Department", "judgment", "export-bucket")
   private lazy val causeOfFailure = "Cause of failure"
-  private lazy val exportStatus1 = ExportStatusEvent(UUID.randomUUID(), true, "intg", Some(successDetailsStandard), None)
-  private lazy val exportStatus2 = ExportStatusEvent(UUID.randomUUID(), true, "intg", Some(successDetailsJudgment), None)
-  private lazy val exportStatus3 = ExportStatusEvent(UUID.randomUUID(), true, "intg", Some(successDetailsJudgmentMockBody), None)
-  private lazy val exportStatus4 = ExportStatusEvent(UUID.randomUUID(), false, "intg", None, Some(causeOfFailure))
-  private lazy val exportStatus5 = ExportStatusEvent(UUID.randomUUID(), true, "staging", Some(successDetailsStandard), None)
-  private lazy val exportStatus6 = ExportStatusEvent(UUID.randomUUID(), true, "staging", Some(successDetailsJudgment), None)
-  private lazy val exportStatus7 = ExportStatusEvent(UUID.randomUUID(), true, "staging", Some(successDetailsJudgmentMockBody), None)
-  private lazy val exportStatus8 = ExportStatusEvent(UUID.randomUUID(), false, "staging", None, Some(causeOfFailure))
-  private lazy val exportStatus9 = ExportStatusEvent(UUID.randomUUID(), false, "intg", None, None)
-  private lazy val exportStatus10 = ExportStatusEvent(UUID.randomUUID(), false, "staging", None, None)
-  private lazy val exportStatus11 = ExportStatusEvent(UUID.randomUUID(), true, "prod", Some(successDetailsStandard), None)
-  private lazy val exportStatus12 = ExportStatusEvent(UUID.randomUUID(), false, "prod", None, Some(causeOfFailure))
+  private lazy val exportStatus1 = ExportStatusEvent(UUID.randomUUID(), success = true, environment = "intg", successDetails = Some(successDetailsStandard), failureCause = None)
+  private lazy val exportStatus2 = ExportStatusEvent(UUID.randomUUID(), success = true, "intg", Some(successDetailsJudgment), None)
+  private lazy val exportStatus3 = ExportStatusEvent(UUID.randomUUID(), success = true, "intg", Some(successDetailsJudgmentMockBody), None)
+  private lazy val exportStatus4 = ExportStatusEvent(UUID.randomUUID(), success = false, "intg", None, Some(causeOfFailure))
+  private lazy val exportStatus5 = ExportStatusEvent(UUID.randomUUID(), success = true, "staging", Some(successDetailsStandard), None)
+  private lazy val exportStatus6 = ExportStatusEvent(UUID.randomUUID(), success = true, "staging", Some(successDetailsJudgment), None)
+  private lazy val exportStatus7 = ExportStatusEvent(UUID.randomUUID(), success = true, "staging", Some(successDetailsJudgmentMockBody), None)
+  private lazy val exportStatus8 = ExportStatusEvent(UUID.randomUUID(), success = false, "staging", None, Some(causeOfFailure))
+  private lazy val exportStatus9 = ExportStatusEvent(UUID.randomUUID(), success = false, "intg", None, None)
+  private lazy val exportStatus10 = ExportStatusEvent(UUID.randomUUID(), success = false, "staging", None, None)
+  private lazy val exportStatus11 = ExportStatusEvent(UUID.randomUUID(), success = true, "prod", Some(successDetailsStandard), None)
+  private lazy val exportStatus12 = ExportStatusEvent(UUID.randomUUID(), success = false, "prod", None, Some(causeOfFailure))
+  private lazy val exportStatus13 = ExportStatusEvent(UUID.randomUUID(), success = true, "prod", Some(successDetailsJudgment), None)
 
   private def exportStatusEventInputText(exportStatusEvent: ExportStatusEvent): String = {
     val successDetails = exportStatusEvent.successDetails
@@ -65,7 +68,7 @@ class ExportIntegrationSpec extends LambdaIntegrationSpec {
        |    "Records": [
        |        {
        |            "Sns": {
-       |                "Message": "{\\"success\\":${exportStatusEvent.success},\\"consignmentId\\":\\"${exportStatusEvent.consignmentId}\\", \\"environment\\": \\"${exportStatusEvent.environment}\\"${exportOutputJson}}"
+       |                "Message": "{\\"success\\":${exportStatusEvent.success},\\"consignmentId\\":\\"${exportStatusEvent.consignmentId}\\", \\"environment\\": \\"${exportStatusEvent.environment}\\"$exportOutputJson}"
        |            }
        |        }
        |    ]

--- a/src/test/scala/uk/gov/nationalarchives/notifications/KeycloakEventIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/KeycloakEventIntegrationSpec.scala
@@ -1,14 +1,13 @@
 package uk.gov.nationalarchives.notifications
 
 import com.github.tomakehurst.wiremock.client.WireMock.{postRequestedFor, urlEqualTo}
-import org.scalatest.prop.TableFor6
-import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportSuccessDetails
+import org.scalatest.prop.TableFor7
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
 
 class KeycloakEventIntegrationSpec extends LambdaIntegrationSpec {
-  override lazy val events: TableFor6[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], () => Unit] = Table(
-    ("description", "input", "emailBody", "slackBody", "sqsMessage", "stubContext"),
-    ("a keycloak event message", scanEventInputText(keycloakEvent), None, Some(expectedKeycloakEventSlackMessage), None, () => ())
+  override lazy val events: TableFor7[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], () => Unit, String] = Table(
+    ("description", "input", "emailBody", "slackBody", "sqsMessage", "stubContext", "slackUrl"),
+    ("a keycloak event message", scanEventInputText(keycloakEvent), None, Some(expectedKeycloakEventSlackMessage), None, () => (), "/webhook-tdr")
   )
   private lazy val keycloakEvent = KeycloakEvent("tdrEnv", "Some keycloak event message")
 
@@ -41,7 +40,7 @@ class KeycloakEventIntegrationSpec extends LambdaIntegrationSpec {
     val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
     new Lambda().process(stream, null)
     wiremockSlackServer.verify(0,
-      postRequestedFor(urlEqualTo("/webhook"))
+      postRequestedFor(urlEqualTo("/webhook-tdr"))
     )
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaSpecUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaSpecUtils.scala
@@ -50,6 +50,8 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
 
   override def beforeEach(): Unit = {
     wiremockSlackServer.stubFor(post(urlEqualTo("/webhook")).willReturn(ok("")))
+    wiremockSlackServer.stubFor(post(urlEqualTo("/webhook-judgment")).willReturn(ok("")))
+    wiremockSlackServer.stubFor(post(urlEqualTo("/webhook-tdr")).willReturn(ok("")))
     wiremockSesEndpoint.stubFor(post(urlEqualTo("/"))
       .willReturn(ok(
         """
@@ -73,7 +75,7 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
     wiremockSlackServer.resetAll()
     wiremockSesEndpoint.resetAll()
     wiremockKmsEndpoint.resetAll()
-    transformEngineQueueHelper.deleteQueue
+    transformEngineQueueHelper.deleteQueue()
 
     super.afterEach()
   }
@@ -115,7 +117,7 @@ class LambdaSpecUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll w
     def createQueue: CreateQueueResponse = sqsClient.createQueue(
       CreateQueueRequest.builder.queueName(queueUrl.split("/")(4)).attributes(visibilityTimeoutAttributes).build()
     )
-    def deleteQueue: DeleteQueueResponse = sqsClient.deleteQueue(DeleteQueueRequest.builder.queueUrl(queueUrl).build())
+    def deleteQueue(): DeleteQueueResponse = sqsClient.deleteQueue(DeleteQueueRequest.builder.queueUrl(queueUrl).build())
   }
 
   val port = 8002

--- a/src/test/scala/uk/gov/nationalarchives/notifications/TransformEngineRetryIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/TransformEngineRetryIntegrationSpec.scala
@@ -1,23 +1,23 @@
 package uk.gov.nationalarchives.notifications
 
-import java.util.UUID
-
-import org.scalatest.prop.TableFor6
+import org.scalatest.prop.TableFor7
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportSuccessDetails
 import uk.gov.nationalarchives.notifications.decoders.TransformEngineRetryDecoder.TransformEngineRetryEvent
 
+import java.util.UUID
+
 class TransformEngineRetryIntegrationSpec extends LambdaIntegrationSpec {
 
-  override lazy val events: TableFor6[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], () => Unit] = Table(
-    ("description", "input", "emailBody", "slackBody", "sqsMessage", "stubContext"),
+  override lazy val events: TableFor7[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], () => Unit, String] = Table(
+    ("description", "input", "emailBody", "slackBody", "sqsMessage", "stubContext", "slackUrl"),
     ("a judgment transform engine retry event on intg",
-      transformEngineRetryEventInputText(judgmentRetryEvent), None, None, Some(SqsExpectedMessageDetails(successDetails, 2)), () => ()),
+      transformEngineRetryEventInputText(judgmentRetryEvent), None, None, Some(SqsExpectedMessageDetails(successDetails, 2)), () => (), "/webhook"),
     ("a standard transform engine retry event on intg",
-      transformEngineRetryEventInputText(standardRetryEvent), None, None, None, () => ()),
+      transformEngineRetryEventInputText(standardRetryEvent), None, None, None, () => (), "/webhook"),
     ("a judgment transform engine event on staging",
-      transformEngineRetryEventInputText(judgmentRetryEvent), None, None, Some(SqsExpectedMessageDetails(successDetails, 2)), () => ()),
+      transformEngineRetryEventInputText(judgmentRetryEvent), None, None, Some(SqsExpectedMessageDetails(successDetails, 2)), () => (), "/webhook"),
     ("a standard transform engine retry event on staging",
-      transformEngineRetryEventInputText(standardRetryEvent), None, None, None, () => ())
+      transformEngineRetryEventInputText(standardRetryEvent), None, None, None, () => (), "/webhook")
   )
 
   private lazy val successDetails = ExportSuccessDetails(UUID.randomUUID(), "consignmentRef1", "tb-body1", "judgment", "judgment-export-bucket")


### PR DESCRIPTION
Keycloak events are still sent to the main da-tdr channel.

I've also changed it so that only export events with a judgment
consignment type are sent to the judgments channel.

I've updated the tests to have a slack webhook parameter so we can check
they're being sent to the right places.
