### PR TITLE
Add Cloudwatch alarm notifications.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
@@ -4,6 +4,7 @@ import java.io.{InputStream, OutputStream}
 import cats.effect._
 import cats.effect.unsafe.implicits.global
 import io.circe.parser.decode
+import uk.gov.nationalarchives.notifications.decoders.CloudwatchAlarmDecoder.CloudwatchAlarmEvent
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportStatusEvent
 import uk.gov.nationalarchives.notifications.decoders.GenericMessageDecoder.GenericMessagesEvent
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
@@ -24,6 +25,7 @@ class Lambda {
       case keycloakEvent: KeycloakEvent => sendMessages(keycloakEvent)
       case transformEngineRetryEvent: TransformEngineRetryEvent => sendMessages(transformEngineRetryEvent)
       case genericMessagesEvent: GenericMessagesEvent => sendMessages(genericMessagesEvent)
+      case cloudwatchAlarmEvent: CloudwatchAlarmEvent => sendMessages(cloudwatchAlarmEvent)
     }).flatten.unsafeRunSync()
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/LambdaRunner.scala
@@ -52,13 +52,13 @@ object LambdaRunner extends App {
          |
          |""".stripMargin
 
-  val diskSpaceFullMessage =
+  val cloudwatchAlarmMessage =
     s"""
        |{
        |    "Records": [
        |        {
        |            "Sns": {
-       |                "Message": "{\\"AlarmName\\":\\"tdr-jenkins-disk-space-alarm-mgmt\\",\\"NewStateValue\\":\\"OK\\",\\"Trigger\\":{\\"Dimensions\\":[{\\"value\\":\\"Jenkins\\",\\"name\\":\\"server_name\\"}],\\"Threshold\\":20.0}}"
+       |                "Message": "{\\"AlarmName\\":\\"DDoSDetectedAlarmForProtection\\",\\"NewStateValue\\":\\"ALARM\\",\\"NewStateReason\\":\\"Test Reason\\", \\"Trigger\\":{\\"MetricName\\": \\"TestName\\", \\"Dimensions\\":[{\\"value\\":\\"test-resource-arn\\",\\"name\\":\\"ResourceArn\\"}]}}"
        |            }
        |        }
        |    ]
@@ -89,7 +89,7 @@ object LambdaRunner extends App {
        |  ]}
        |""".stripMargin
 
-  val inputStream = new ByteArrayInputStream(genericMessage.getBytes)
+  val inputStream = new ByteArrayInputStream(cloudwatchAlarmMessage.getBytes)
 
   // The Lambda does not use the output stream, so it's safe to set it to null
   val outputStream = null

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/CloudwatchAlarmDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/CloudwatchAlarmDecoder.scala
@@ -1,0 +1,8 @@
+package uk.gov.nationalarchives.notifications.decoders
+
+object CloudwatchAlarmDecoder {
+
+  case class AlarmDimension(name: String, `value`: String)
+  case class AlarmTrigger(Dimensions: List[AlarmDimension], MetricName: String)
+  case class CloudwatchAlarmEvent(NewStateValue: String, Trigger: AlarmTrigger, NewStateReason: String) extends IncomingEvent
+}

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
@@ -4,6 +4,7 @@ import io.circe.CursorOp.DownField
 import io.circe.parser.parse
 import io.circe.generic.auto._
 import io.circe.{Decoder, DecodingFailure, HCursor, Json}
+import uk.gov.nationalarchives.notifications.decoders.CloudwatchAlarmDecoder.CloudwatchAlarmEvent
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.decodeScanEvent
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportStatusEvent
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
@@ -15,7 +16,8 @@ trait IncomingEvent {
 
 object IncomingEvent {
   implicit val allDecoders: Decoder[IncomingEvent] = decodeScanEvent or decodeSnsEvent[ExportStatusEvent] or
-    decodeSnsEvent[KeycloakEvent] or decodeSqsEvent[TransformEngineRetryEvent] or decodeSnsEvent[GenericMessagesEvent]
+    decodeSnsEvent[KeycloakEvent] or decodeSqsEvent[TransformEngineRetryEvent] or decodeSnsEvent[GenericMessagesEvent] or
+    decodeSnsEvent[CloudwatchAlarmEvent]
 
   def decodeSnsEvent[T <: IncomingEvent]()(implicit decoder: Decoder[T]): Decoder[IncomingEvent] = (c: HCursor) => for {
     messages <- c.downField("Records").as[List[SnsRecord]]

--- a/src/test/scala/uk/gov/nationalarchives/notifications/CloudwatchAlarmIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/CloudwatchAlarmIntegrationSpec.scala
@@ -1,0 +1,58 @@
+package uk.gov.nationalarchives.notifications
+
+import org.scalatest.prop.TableFor7
+import cats.syntax.all._
+
+class CloudwatchAlarmIntegrationSpec extends LambdaIntegrationSpec {
+  private def event(status: String, metricName: String, newStateReason: String, dimensionName: String, dimensionValue: String): String = {
+    s"""
+       |{
+       |    "Records": [
+       |        {
+       |            "Sns": {
+       |                "Message": "{\\"NewStateReason\\": \\"$newStateReason\\",\\"NewStateValue\\":\\"$status\\",\\"Trigger\\":{\\"MetricName\\": \\"$metricName\\", \\"Dimensions\\":[{\\"value\\":\\"$dimensionValue\\",\\"name\\":\\"$dimensionName\\"}]}}"
+       |            }
+       |        }
+       |    ]
+       |}
+       |
+       |""".stripMargin
+  }
+
+  private def slackMessage(status: String, metricName: String, newStateReason: String, dimensions: String): Option[String] = {
+    s"""{
+       |  "blocks": [
+       |    {
+       |      "type": "section",
+       |      "text": {
+       |        "type": "mrkdwn",
+       |        "text": "*Cloudwatch Alarms*\\nAlarm state $status\\nAlarm triggered by $metricName\\nReason: $newStateReason\\n\\n*Dimensions affected*\\n$dimensions"
+       |      }
+       |    }
+       |  ]
+       |}
+       |""".stripMargin.some
+  }
+
+  override def events: TableFor7[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], () => Unit, String] = Table(
+    ("description", "input", "emailBody", "slackBody", "sqsMessage", "stubContext", "slackUrl"),
+    (
+      "Alarm Test1 with state OK, reason TestReason1, dimensions test1Name - test1Value",
+      event("OK", "Test1", "TestReason1", "test1Name", "test1Value"),
+      None,
+      slackMessage("OK", "Test1", "TestReason1", "test1Name - test1Value"),
+      None,
+      () => (),
+      "/webhook"
+    ),
+    (
+      "Alarm Test2 with state ALARM, reason TestReason2, dimensions test2Name - test2Value",
+      event("ALARM", "Test2", "TestReason2", "test2Name", "test2Value"),
+      None,
+      slackMessage("ALARM", "Test2", "TestReason2", "test2Name - test2Value"),
+      None,
+      () => (),
+      "/webhook"
+    )
+  )
+}


### PR DESCRIPTION
This will initially be used for the DDOS alert Cloudwatch alarms we get
from AWS advanced shield but there's nothing to stop us setting up other
Cloudwatch alarms, in which case this will work for those as well.
