### PR TITLE
Filter 'tre-out' topic messages

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
@@ -11,7 +11,7 @@ import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.Keycl
 import uk.gov.nationalarchives.notifications.decoders.GovUkNotifyKeyRotationDecoder.GovUkNotifyKeyRotationEvent
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.ScanEvent
 import uk.gov.nationalarchives.notifications.decoders.TransformEngineRetryDecoder.TransformEngineRetryEvent
-import uk.gov.nationalarchives.notifications.decoders.TransformEngineV2Decoder.TransformEngineV2RetryEvent
+import uk.gov.nationalarchives.notifications.decoders.TransformEngineV2Decoder.TransformEngineV2OutEvent
 import uk.gov.nationalarchives.notifications.decoders._
 import uk.gov.nationalarchives.notifications.messages.EventMessages._
 import uk.gov.nationalarchives.notifications.messages.Messages._
@@ -26,7 +26,7 @@ class Lambda {
       case exportStatus: ExportStatusEvent => sendMessages(exportStatus)
       case keycloakEvent: KeycloakEvent => sendMessages(keycloakEvent)
       case transformEngineRetryEvent: TransformEngineRetryEvent => sendMessages(transformEngineRetryEvent)
-      case transformEngineV2RetryEvent: TransformEngineV2RetryEvent => sendMessages(transformEngineV2RetryEvent)
+      case transformEngineV2RetryEvent: TransformEngineV2OutEvent => sendMessages(transformEngineV2RetryEvent)
       case genericMessagesEvent: GenericMessagesEvent => sendMessages(genericMessagesEvent)
       case cloudwatchAlarmEvent: CloudwatchAlarmEvent => sendMessages(cloudwatchAlarmEvent)
       case govUkNotifyKeyRotationEvent: GovUkNotifyKeyRotationEvent => sendMessages(govUkNotifyKeyRotationEvent)

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
@@ -12,7 +12,7 @@ import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.Keycl
 import uk.gov.nationalarchives.notifications.decoders.GenericMessageDecoder.GenericMessagesEvent
 import uk.gov.nationalarchives.notifications.decoders.GovUkNotifyKeyRotationDecoder.GovUkNotifyKeyRotationEvent
 import uk.gov.nationalarchives.notifications.decoders.TransformEngineRetryDecoder.TransformEngineRetryEvent
-import uk.gov.nationalarchives.notifications.decoders.TransformEngineV2Decoder.{TransformEngineV2RetryEvent, UUIDs, TdrUUID, TreUUID}
+import uk.gov.nationalarchives.notifications.decoders.TransformEngineV2Decoder.{TransformEngineV2OutEvent, UUIDs, TdrUUID, TreUUID}
 
 trait IncomingEvent {
 }
@@ -21,7 +21,7 @@ object IncomingEvent {
   implicit val uuidDecoder: Decoder[UUIDs] = Decoder[TdrUUID].widen or Decoder[TreUUID].widen
   implicit val allDecoders: Decoder[IncomingEvent] = decodeScanEvent or decodeSnsEvent[ExportStatusEvent] or
     decodeSnsEvent[KeycloakEvent] or decodeSqsEvent[TransformEngineRetryEvent] or decodeSnsEvent[GenericMessagesEvent] or
-    decodeSnsEvent[CloudwatchAlarmEvent] or decodeSnsEvent[GovUkNotifyKeyRotationEvent] or decodeSqsEvent[TransformEngineV2RetryEvent]
+    decodeSnsEvent[CloudwatchAlarmEvent] or decodeSnsEvent[GovUkNotifyKeyRotationEvent] or decodeSqsEvent[TransformEngineV2OutEvent]
 
   def decodeSnsEvent[T <: IncomingEvent]()(implicit decoder: Decoder[T]): Decoder[IncomingEvent] = (c: HCursor) => for {
     messages <- c.downField("Records").as[List[SnsRecord]]

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/TransformEngineV2Decoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/TransformEngineV2Decoder.scala
@@ -23,6 +23,10 @@ object TransformEngineV2Decoder {
     def producer: Producer
 
     def parameters: Parameters
+
+    def retryEvent: Boolean = {
+      producer.`event-name` == "bagit-validation-error"
+    }
   }
 
   trait ResourceDetails {
@@ -58,13 +62,13 @@ object TransformEngineV2Decoder {
 
   case class TreUUID(`TRE-UUID`: UUID) extends UUIDs
 
-  case class TransformEngineV2RetryEvent(`version`: String = treVersion, `timestamp`: Long, UUIDs: List[UUIDs],
-                                         producer: Producer,
-                                         parameters: ErrorParameters) extends IncomingEvent with TransformEngineV2Event
+  case class TransformEngineV2OutEvent(`version`: String = treVersion, `timestamp`: Long, UUIDs: List[UUIDs],
+                                       producer: Producer,
+                                       parameters: ErrorParameters) extends IncomingEvent with TransformEngineV2Event
 
-  case class TransferEngineV2NewBagitEvent(`version`: String = treVersion, `timestamp`: Long, UUIDs: List[UUIDs],
-                                           producer: Producer,
-                                           parameters: NewBagitParameters) extends TransformEngineV2Event
+  case class TransferEngineV2InEvent(`version`: String = treVersion, `timestamp`: Long, UUIDs: List[UUIDs],
+                                     producer: Producer,
+                                     parameters: NewBagitParameters) extends TransformEngineV2Event
 
 
   implicit val encodeUUIDs: Encoder[UUIDs] = {

--- a/src/test/scala/uk/gov/nationalarchives/notifications/TransformEngineV2RetryIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/TransformEngineV2RetryIntegrationSpec.scala
@@ -3,7 +3,7 @@ package uk.gov.nationalarchives.notifications
 import org.scalatest.prop.TableFor8
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportSuccessDetails
 import uk.gov.nationalarchives.notifications.decoders.TransformEngineRetryDecoder.TransformEngineRetryEvent
-import uk.gov.nationalarchives.notifications.decoders.TransformEngineV2Decoder.{BagitValidationError, ErrorParameters, Producer, TransformEngineV2RetryEvent}
+import uk.gov.nationalarchives.notifications.decoders.TransformEngineV2Decoder.{BagitValidationError, ErrorParameters, Producer, TransformEngineV2OutEvent}
 
 import java.util.UUID
 
@@ -11,38 +11,53 @@ class TransformEngineV2RetryIntegrationSpec extends LambdaIntegrationSpec {
 
   override lazy val events: TableFor8[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], Option[SnsExpectedMessageDetails], () => Unit, String] = Table(
     ("description", "input", "emailBody", "slackBody", "sqsMessage", "snsMessage", "stubContext", "slackUrl"),
-    ("a judgment transform engine retry event on intg",
+    ("a judgment transform engine 'retry' event on intg",
       transformEngineRetryEventInputText(judgmentRetryEvent), None, None, None, expectedDetails(judgmentRetryEvent), () => (), "/webhook"),
-    ("a standard transform engine retry event on intg",
+    ("a judgment transform engine 'non-retry' event on intg",
+      transformEngineRetryEventInputText(judgmentNonRetryEvent), None, None, None, None, () => (), "/webhook"),
+    ("a standard transform engine 'retry' event on intg",
       transformEngineRetryEventInputText(standardRetryEvent), None, None, None, expectedDetails(standardRetryEvent), () => (), "/webhook"),
-    ("a judgment transform engine event on staging",
+    ("a standard transform engine 'non-retry' event on intg",
+      transformEngineRetryEventInputText(standardNonRetryEvent), None, None, None, None, () => (), "/webhook"),
+    ("a judgment transform engine 'retry' event on staging",
       transformEngineRetryEventInputText(judgmentRetryEvent), None, None, None, expectedDetails(judgmentRetryEvent), () => (), "/webhook"),
-    ("a standard transform engine retry event on staging",
+    ("a judgment transform engine 'non-retry' event on staging",
+      transformEngineRetryEventInputText(judgmentNonRetryEvent), None, None, None, None, () => (), "/webhook"),
+    ("a standard transform engine 'retry' event on staging",
       transformEngineRetryEventInputText(standardRetryEvent), None, None, None, expectedDetails(standardRetryEvent), () => (), "/webhook"),
-    ("a judgment transform engine event on prod",
+    ("a standard transform engine 'non-retry' event on staging",
+      transformEngineRetryEventInputText(standardNonRetryEvent), None, None, None, None, () => (), "/webhook"),
+    ("a judgment transform engine 'retry' event on prod",
       transformEngineRetryEventInputText(judgmentRetryEvent), None, None, None, expectedDetails(judgmentRetryEvent), () => (), "/webhook"),
-    ("a standard transform engine retry event on prod",
-      transformEngineRetryEventInputText(standardRetryEvent), None, None, None, expectedDetails(standardRetryEvent), () => (), "/webhook")
+    ("a judgment transform engine 'non-retry' event on prod",
+      transformEngineRetryEventInputText(judgmentNonRetryEvent), None, None, None, None, () => (), "/webhook"),
+    ("a standard transform engine 'retry' event on prod",
+      transformEngineRetryEventInputText(standardRetryEvent), None, None, None, expectedDetails(standardRetryEvent), () => (), "/webhook"),
+    ("a standard transform engine 'non-retry' event on prod",
+      transformEngineRetryEventInputText(standardNonRetryEvent), None, None, None, None, () => (), "/webhook")
   )
 
-  private lazy val judgmentRetryEvent: TransformEngineV2RetryEvent = createRetryEvent("judgment")
+  private lazy val judgmentRetryEvent: TransformEngineV2OutEvent = createRetryEvent("judgment")
+  private lazy val judgmentNonRetryEvent: TransformEngineV2OutEvent = createRetryEvent("judgment", "non-retry-event")
   private lazy val standardRetryEvent = createRetryEvent("standard")
+  private lazy val standardNonRetryEvent = createRetryEvent("standard","non-retry-event")
 
-  private def transformEngineRetryEventInputText(retryEvent: TransformEngineV2RetryEvent): String = {
+  private def transformEngineRetryEventInputText(retryEvent: TransformEngineV2OutEvent): String = {
     val consignmentType = retryEvent.producer.`type`
+    val eventName = retryEvent.producer.`event-name`
 
     s"""
        |{
        |  "Records": [
        |        {
-       |          "body": "{\\"version\\": \\"1.0.0\\",\\"timestamp\\" :1661340417609575000,\\"UUIDs\\": [{\\"TDR-UUID\\": \\"c73e5ca7-cf87-442a-8248-e05f81361ae0\\"},{\\"TRE-UUID\\": \\"ec506d7f-f531-4e63-833e-841918105e41\\"}],\\"producer\\": {\\"environment\\": \\"dev\\",\\"name\\": \\"TRE\\",\\"process\\": \\"dev-tre-validate-bagit\\",\\"event-name\\": \\"bagit-validation-error\\",\\"type\\": \\"$consignmentType\\"},\\"parameters\\": {\\"bagit-validation-error\\": {\\"reference\\": \\"ABC-1234-DEF\\",\\"errors\\": [\\"some error message\\"]}}}"
+       |          "body": "{\\"version\\": \\"1.0.0\\",\\"timestamp\\" :1661340417609575000,\\"UUIDs\\": [{\\"TDR-UUID\\": \\"c73e5ca7-cf87-442a-8248-e05f81361ae0\\"},{\\"TRE-UUID\\": \\"ec506d7f-f531-4e63-833e-841918105e41\\"}],\\"producer\\": {\\"environment\\": \\"dev\\",\\"name\\": \\"TRE\\",\\"process\\": \\"dev-tre-validate-bagit\\",\\"event-name\\": \\"$eventName\\",\\"type\\": \\"$consignmentType\\"},\\"parameters\\": {\\"bagit-validation-error\\": {\\"reference\\": \\"ABC-1234-DEF\\",\\"errors\\": [\\"some error message\\"]}}}"
        |        }
        |    ]
        |}
        |""".stripMargin
   }
 
-  private def expectedDetails(retryEvent: TransformEngineV2RetryEvent): Option[SnsExpectedMessageDetails] = {
+  private def expectedDetails(retryEvent: TransformEngineV2OutEvent): Option[SnsExpectedMessageDetails] = {
     val consignmentType: String = retryEvent.producer.`type`
     val consignmentRef: String = retryEvent.parameters.`bagit-validation-error`.reference
     val environment: String = retryEvent.producer.environment
@@ -55,10 +70,10 @@ class TransformEngineV2RetryIntegrationSpec extends LambdaIntegrationSpec {
     Some(SnsExpectedMessageDetails(consignmentRef, consignmentType, bucket, environment))
   }
 
-  private def createRetryEvent(consignmentType: String): TransformEngineV2RetryEvent = {
-    val producer = Producer("dev", "tre", "dev-tre-validate-bagit", "bagit-validation-error", consignmentType)
+  private def createRetryEvent(consignmentType: String, eventName: String = "bagit-validation-error"): TransformEngineV2OutEvent = {
+    val producer = Producer("dev", "tre", "dev-tre-validate-bagit", eventName, consignmentType)
     val validationError = BagitValidationError("ABC-1234-DEF", Some(List("some error message")))
     val parameters = ErrorParameters(validationError)
-    TransformEngineV2RetryEvent(`timestamp` = 1661340417609575000L, UUIDs = List(), producer = producer, parameters = parameters)
+    TransformEngineV2OutEvent(`timestamp` = 1661340417609575000L, UUIDs = List(), producer = producer, parameters = parameters)
   }
 }


### PR DESCRIPTION
'tre-out' SNS topic message do not use 'message attributes'

SNS topic subscription filtering only works with 'message attributes'

Notifications lambda will need to provide filtering on the messages to ensure only the correct 'tre-out' message trigger a retry export message to 'tre-in' SNS topic