### PR TITLE
Add backend checks failure notifications.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
@@ -10,6 +10,7 @@ import uk.gov.nationalarchives.notifications.decoders.GenericMessageDecoder.Gene
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
 import uk.gov.nationalarchives.notifications.decoders.ParameterStoreExpiryEventDecoder.ParameterStoreExpiryEvent
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.ScanEvent
+import uk.gov.nationalarchives.notifications.decoders.StepFunctionErrorDecoder.StepFunctionError
 import uk.gov.nationalarchives.notifications.decoders.TransformEngineRetryDecoder.TransformEngineRetryEvent
 import uk.gov.nationalarchives.notifications.decoders.TransformEngineV2Decoder.TransformEngineV2OutEvent
 import uk.gov.nationalarchives.notifications.decoders._
@@ -30,6 +31,7 @@ class Lambda {
       case genericMessagesEvent: GenericMessagesEvent => sendMessages(genericMessagesEvent)
       case cloudwatchAlarmEvent: CloudwatchAlarmEvent => sendMessages(cloudwatchAlarmEvent)
       case parameterStoreExpiryEvent: ParameterStoreExpiryEvent => sendMessages(parameterStoreExpiryEvent)
+      case stepFunctionError: StepFunctionError => sendMessages(stepFunctionError)
     }).flatten.unsafeRunSync()
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
@@ -11,8 +11,9 @@ import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.Export
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
 import uk.gov.nationalarchives.notifications.decoders.GenericMessageDecoder.GenericMessagesEvent
 import uk.gov.nationalarchives.notifications.decoders.ParameterStoreExpiryEventDecoder.ParameterStoreExpiryEvent
+import uk.gov.nationalarchives.notifications.decoders.StepFunctionErrorDecoder.decodeStepFunctionError
 import uk.gov.nationalarchives.notifications.decoders.TransformEngineRetryDecoder.TransformEngineRetryEvent
-import uk.gov.nationalarchives.notifications.decoders.TransformEngineV2Decoder.{TransformEngineV2OutEvent, UUIDs, TdrUUID, TreUUID}
+import uk.gov.nationalarchives.notifications.decoders.TransformEngineV2Decoder.{TdrUUID, TransformEngineV2OutEvent, TreUUID, UUIDs}
 
 trait IncomingEvent {
 }
@@ -21,7 +22,9 @@ object IncomingEvent {
   implicit val uuidDecoder: Decoder[UUIDs] = Decoder[TdrUUID].widen or Decoder[TreUUID].widen
   implicit val allDecoders: Decoder[IncomingEvent] = decodeScanEvent or decodeSnsEvent[ExportStatusEvent] or
     decodeSnsEvent[KeycloakEvent] or decodeSqsEvent[TransformEngineRetryEvent] or decodeSnsEvent[GenericMessagesEvent] or
-    decodeSnsEvent[CloudwatchAlarmEvent] or decodeSnsEvent[ParameterStoreExpiryEvent] or decodeSqsWithSnsMessageEvent[TransformEngineV2OutEvent]
+    decodeSnsEvent[CloudwatchAlarmEvent] or decodeSnsEvent[ParameterStoreExpiryEvent] or decodeSqsWithSnsMessageEvent[TransformEngineV2OutEvent] or
+    decodeStepFunctionError
+
 
   def decodeSnsEvent[T <: IncomingEvent]()(implicit decoder: Decoder[T]): Decoder[IncomingEvent] = (c: HCursor) => for {
     messages <- c.downField("Records").as[List[SnsRecord]]

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/StepFunctionErrorDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/StepFunctionErrorDecoder.scala
@@ -1,0 +1,16 @@
+package uk.gov.nationalarchives.notifications.decoders
+
+import io.circe.{Decoder, HCursor}
+
+import java.util.UUID
+
+object StepFunctionErrorDecoder {
+  case class StepFunctionError(consignmentId: UUID, error: String, cause: String, environment: String) extends IncomingEvent
+
+  val decodeStepFunctionError: Decoder[IncomingEvent] = (c: HCursor) => for {
+    error <- c.downField("error").as[String]
+    cause <- c.downField("cause").as[String]
+    environment <- c.downField("environment").as[String]
+    consignmentId <- c.downField("consignmentId").as[UUID]
+  } yield StepFunctionError(consignmentId, error, cause, environment)
+}

--- a/src/test/scala/uk/gov/nationalarchives/notifications/StepFunctionErrorIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/StepFunctionErrorIntegrationSpec.scala
@@ -1,0 +1,46 @@
+package uk.gov.nationalarchives.notifications
+
+import io.circe.Printer
+
+import org.scalatest.prop.TableFor8
+import io.circe.syntax._
+import io.circe.generic.auto._
+import uk.gov.nationalarchives.notifications.decoders.StepFunctionErrorDecoder.StepFunctionError
+
+import java.util.UUID
+
+class StepFunctionErrorIntegrationSpec extends LambdaIntegrationSpec {
+  override lazy val events: TableFor8[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], Option[SnsExpectedMessageDetails], () => Unit, String] = Table(
+    ("description", "input", "emailBody", "slackBody", "sqsMessage", "snsMessage", "stubContext", "slackUrl"),
+    ("a step function error on intg",
+      stepFunctionErrorInput(stepFunctionError("intg")), None, None, None, None, () => (), "/webhook"),
+    ("a step function error on staging",
+      stepFunctionErrorInput(stepFunctionError("staging")), None, slackMessage(stepFunctionError("staging")), None, None, () => (), "/webhook"),
+    ("a step function error on prod",
+      stepFunctionErrorInput(stepFunctionError("prod")), None, slackMessage(stepFunctionError("prod")), None, None, () => (), "/webhook"),
+  )
+
+  def stepFunctionError(environment: String): StepFunctionError = {
+    val id = UUID.fromString("49d364ab-8bc3-4c53-90ca-d3f003179cb9")
+    StepFunctionError(id ,"error", "cause", environment)
+  }
+
+  def stepFunctionErrorInput(stepFunctionError: StepFunctionError): String = {
+    stepFunctionError.asJson.printWith(Printer.noSpaces)
+  }
+
+  def  slackMessage(stepFunctionError: StepFunctionError): Option[String] = Option {
+    s"""{
+       |  "blocks": [
+       |    {
+       |      "type": "section",
+       |      "text": {
+       |        "type": "mrkdwn",
+       |        "text": ":warning: *Backend checks failure for consignment*\\n*ConsignmentId* ${stepFunctionError.consignmentId}\\n*Environment* ${stepFunctionError.environment}\\n*Cause*: ${stepFunctionError.cause}\\n*Error*: ${stepFunctionError.error}"
+       |      }
+       |    }
+       |  ]
+       |}
+       |""".stripMargin
+  }
+}


### PR DESCRIPTION
There is a catch block on the step function inside the backend checks
definition which calls the notifications service if any of the checks
fail.

This change will send a message when there is an error
