### PR TITLE
Notifications integration spec tests- readability refactor

### DIFF
--- a/src/test/scala/uk/gov/nationalarchives/notifications/CloudwatchAlarmIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/CloudwatchAlarmIntegrationSpec.scala
@@ -19,7 +19,7 @@ class CloudwatchAlarmIntegrationSpec extends LambdaIntegrationSpec {
        |""".stripMargin
   }
 
-  private def slackMessage(status: String, metricName: String, newStateReason: String, dimensions: String): Option[String] = {
+  private def slackMessage(status: String, metricName: String, newStateReason: String, dimensions: String): String = {
     s"""{
        |  "blocks": [
        |    {
@@ -31,30 +31,23 @@ class CloudwatchAlarmIntegrationSpec extends LambdaIntegrationSpec {
        |    }
        |  ]
        |}
-       |""".stripMargin.some
+       |""".stripMargin
   }
 
-  override def events: TableFor8[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], Option[SnsExpectedMessageDetails], () => Unit, String] = Table(
-    ("description", "input", "emailBody", "slackBody", "sqsMessage", "snsMessage", "stubContext", "slackUrl"),
-    (
-      "Alarm Test1 with state OK, reason TestReason1, dimensions test1Name - test1Value",
-      event("OK", "Test1", "TestReason1", "test1Name", "test1Value"),
-      None,
-      slackMessage("OK", "Test1", "TestReason1", "test1Name - test1Value"),
-      None,
-      None,
-      () => (),
-      "/webhook"
+  override def events: Seq[Event] = Seq(
+    Event(
+      description = "Alarm Test1 with state OK, reason TestReason1, dimensions test1Name - test1Value",
+      input = event("OK", "Test1", "TestReason1", "test1Name", "test1Value"),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = slackMessage("OK", "Test1", "TestReason1", "test1Name - test1Value"), webhookUrl = "/webhook"))
+      )
     ),
-    (
-      "Alarm Test2 with state ALARM, reason TestReason2, dimensions test2Name - test2Value",
-      event("ALARM", "Test2", "TestReason2", "test2Name", "test2Value"),
-      None,
-      slackMessage("ALARM", "Test2", "TestReason2", "test2Name - test2Value"),
-      None,
-      None,
-      () => (),
-      "/webhook"
+    Event(
+      description = "Alarm Test2 with state ALARM, reason TestReason2, dimensions test2Name - test2Value",
+      input = event("ALARM", "Test2", "TestReason2", "test2Name", "test2Value"),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(slackMessage("ALARM", "Test2", "TestReason2", "test2Name - test2Value"), webhookUrl = "/webhook"))
+      )
     )
   )
 }

--- a/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/ExportIntegrationSpec.scala
@@ -7,44 +7,137 @@ import java.util.UUID
 
 class ExportIntegrationSpec extends LambdaIntegrationSpec {
 
-  override lazy val events: TableFor8[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], Option[SnsExpectedMessageDetails], () => Unit, String] = Table(
-    ("description", "input", "emailBody", "slackBody", "sqsMessage", "snsMessage", "stubContext", "slackUrl"),
-    ("a successful standard export event on intg",
-      exportStatusEventInputText(intgStandardSuccess), None, None, None, expectedSnsMessage(intgStandardSuccess), () => (), "/webhook-export"),
-    ("a successful mock standard export event on intg",
-      exportStatusEventInputText(intgStandardSuccessMock), None, None, None, expectedSnsMessage(intgStandardSuccessMock), () => (), "/webhook-export"),
-    ("a successful judgment export event on intg",
-      exportStatusEventInputText(intgJudgmentSuccess), None, None, None, expectedSnsMessage(intgJudgmentSuccess), () => (), "/webhook-export"),
-    ("a successful mock judgment export event on intg",
-      exportStatusEventInputText(intgJudgmentSuccessMock), None, None, None, expectedSnsMessage(intgJudgmentSuccessMock), () => (), "/webhook-export"),
-    ("a failed export event on intg",
-      exportStatusEventInputText(intgFailure), None, Some(expectedSlackMessage(intgFailure)), None, None, () => (), "/webhook-export"),
-    ("a successful standard export event on staging",
-      exportStatusEventInputText(stagingStandardSuccess), None, Some(expectedSlackMessage(stagingStandardSuccess)), None, expectedSnsMessage(stagingStandardSuccess), () => (), "/webhook-export"),
-    ("a successful mock standard export event on staging",
-      exportStatusEventInputText(stagingStandardSuccessMock), None, Some(expectedSlackMessage(stagingStandardSuccessMock)), None, None, () => (), "/webhook-export"),
-    ("a successful judgment export event on staging",
-      exportStatusEventInputText(stagingJudgmentSuccess), None, Some(expectedSlackMessage(stagingJudgmentSuccess)), None, expectedSnsMessage(stagingJudgmentSuccess), () => (), "/webhook-export"),
-    ("a successful mock judgment export event on staging",
-      exportStatusEventInputText(stagingJudgmentSuccessMock), None, Some(expectedSlackMessage(stagingJudgmentSuccessMock)), None, None, () => (), "/webhook-export"),
-    ("a failed export event on staging",
-      exportStatusEventInputText(stagingFailure), None, Some(expectedSlackMessage(stagingFailure)), None, None, () => (), "/webhook-export"),
-    ("a failed export on intg with no error details",
-      exportStatusEventInputText(intgFailureNoError), None, Some(expectedSlackMessage(intgFailureNoError)), None, None, () => (), "/webhook-export"),
-    ("a failed export on staging with no error details",
-      exportStatusEventInputText(stagingFailureNoError), None, Some(expectedSlackMessage(stagingFailureNoError)), None, None, () => (), "/webhook-export"),
-    ("a successful standard export event on prod",
-      exportStatusEventInputText(prodStandardSuccess), None, Some(expectedSlackMessage(prodStandardSuccess)), None, expectedSnsMessage(prodStandardSuccess), () => (), "/webhook-standard"),
-    ("a successful mock standard export event on prod",
-      exportStatusEventInputText(prodStandardSuccessMock), None, Some(expectedSlackMessage(prodStandardSuccessMock)), None, None, () => (), "/webhook-standard"),
-    ("a failed standard export event on prod",
-      exportStatusEventInputText(prodFailure), None, Some(expectedSlackMessage(prodFailure)), None, None, () => (), "/webhook-export"),
-    ("a failed export event on prod",
-      exportStatusEventInputText(prodFailure), None, Some(expectedSlackMessage(prodFailure)), None, None, () => (), "/webhook-tdr"),
-    ("a successful judgment export on prod",
-      exportStatusEventInputText(prodJudgmentSuccess), None, Some(expectedSlackMessage(prodJudgmentSuccess)), None, expectedSnsMessage(prodJudgmentSuccess), () => (), "/webhook-judgment"),
-    ("a successful mock judgment export on prod",
-      exportStatusEventInputText(prodJudgmentSuccessMock), None, Some(expectedSlackMessage(prodJudgmentSuccessMock)), None, None, () => (), "/webhook-judgment"),
+  override lazy val events: Seq[Event] = Seq(
+    Event(
+      description = "a successful standard export event on intg",
+      input = exportStatusEventInputText(intgStandardSuccess),
+      expectedOutput = ExpectedOutput(
+        snsMessage = expectedSnsMessage(intgStandardSuccess)
+      )
+    ),
+    Event(
+      description = "a successful mock standard export event on intg",
+      input = exportStatusEventInputText(intgStandardSuccessMock),
+      expectedOutput = ExpectedOutput(
+        snsMessage = expectedSnsMessage(intgStandardSuccessMock)
+      )
+    ),
+    Event(
+      description = "a successful judgment export event on intg",
+      input = exportStatusEventInputText(intgJudgmentSuccess),
+      expectedOutput = ExpectedOutput(
+        snsMessage = expectedSnsMessage(intgJudgmentSuccess)
+      )
+    ),
+    Event(
+      description = "a successful mock judgment export event on intg",
+      input = exportStatusEventInputText(intgJudgmentSuccessMock),
+      expectedOutput = ExpectedOutput(
+        snsMessage = expectedSnsMessage(intgJudgmentSuccessMock)
+      )
+    ),
+    Event(
+      description = "a failed export event on intg",
+      input = exportStatusEventInputText(intgFailure),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(intgFailure), webhookUrl = "/webhook-export"))
+      )
+    ),
+    Event(
+      description = "a successful standard export event on staging",
+      input = exportStatusEventInputText(stagingStandardSuccess),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(stagingStandardSuccess), webhookUrl = "/webhook-export")),
+        snsMessage = expectedSnsMessage(stagingStandardSuccess)
+      )
+    ),
+    Event(
+      description = "a successful mock standard export event on staging",
+      input = exportStatusEventInputText(stagingStandardSuccessMock),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(stagingStandardSuccessMock), webhookUrl = "/webhook-export"))
+      )
+    ),
+    Event(
+      description = "a successful judgment export event on staging",
+      input = exportStatusEventInputText(stagingJudgmentSuccess),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(stagingJudgmentSuccess), webhookUrl = "/webhook-export")),
+        snsMessage = expectedSnsMessage(stagingJudgmentSuccess)
+      )
+    ),
+    Event(
+      description = "a successful mock judgment export event on staging",
+      input = exportStatusEventInputText(stagingJudgmentSuccessMock),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(stagingJudgmentSuccessMock), webhookUrl = "/webhook-export"))
+      )
+    ),
+    Event(
+      description = "a failed export event on staging",
+      input = exportStatusEventInputText(stagingFailure),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(stagingFailure), webhookUrl = "/webhook-export"))
+      )
+    ),
+    Event(
+      description = "a failed export on intg with no error details",
+      input = exportStatusEventInputText(intgFailureNoError),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(intgFailureNoError), webhookUrl = "/webhook-export"))
+      )
+    ),
+    Event(
+      description = "a failed export on staging with no error details",
+      input = exportStatusEventInputText(stagingFailureNoError),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(stagingFailureNoError), webhookUrl = "/webhook-export"))
+      )
+    ),
+    Event(
+      description = "a successful standard export event on prod",
+      input = exportStatusEventInputText(prodStandardSuccess),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(prodStandardSuccess), webhookUrl = "/webhook-standard")),
+        snsMessage = expectedSnsMessage(prodStandardSuccess)
+      )
+    ),
+    Event(
+      description = "a successful mock standard export event on prod",
+      input = exportStatusEventInputText(prodStandardSuccessMock),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(prodStandardSuccessMock), webhookUrl = "/webhook-standard"))
+      )
+    ),
+    Event(
+      description = "a failed standard export event on prod",
+      input = exportStatusEventInputText(prodFailure),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(prodFailure), webhookUrl = "/webhook-export"))
+      )
+    ),
+    Event(
+      description = "a failed export event on prod",
+      input = exportStatusEventInputText(prodFailure),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(prodFailure), webhookUrl = "/webhook-tdr"))
+      )
+    ),
+    Event(
+      description = "a successful judgment export on prod",
+      input = exportStatusEventInputText(prodJudgmentSuccess),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(prodJudgmentSuccess), webhookUrl = "/webhook-judgment")),
+        snsMessage = expectedSnsMessage(prodJudgmentSuccess)
+      )
+    ),
+    Event(
+      description = "a successful mock judgment export on prod",
+      input = exportStatusEventInputText(prodJudgmentSuccessMock),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackMessage(prodJudgmentSuccessMock), webhookUrl = "/webhook-judgment"))
+      )
+    )
   )
 
   private lazy val successDetailsStandard = ExportSuccessDetails(UUID.randomUUID(), "consignmentRef1", "tb-body1", "standard", "export-bucket")

--- a/src/test/scala/uk/gov/nationalarchives/notifications/GenericMessageIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/GenericMessageIntegrationSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.prop.TableFor8
 
 class GenericMessageIntegrationSpec extends LambdaIntegrationSpec {
 
-  override def events: TableFor8[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], Option[SnsExpectedMessageDetails], () => Unit, String] = {
+  override def events: Seq[Event] = {
     val oneMessage: String =
       """ "{\"messages\":[{\"message\":\"A test message\"}]}" """
     val oneMessageText = "A test message"
@@ -13,12 +13,21 @@ class GenericMessageIntegrationSpec extends LambdaIntegrationSpec {
       """ "{\"messages\":[{\"message\":\"A test message\"}, {\"message\":\"A second test message\"}]}" """
     val twoMessagesText = "A test message\\nA second test message"
 
-    Table(
-      ("description", "input", "emailBody", "slackBody", "sqsMessage", "snsMessage", "stubContext", "slackUrl"),
-      ("one message",
-        genericEventInput(oneMessage), None, slackMsg(oneMessageText).some, None, None, () => (), "/webhook"),
-      ("two messages",
-        genericEventInput(twoMessages), None, slackMsg(twoMessagesText).some, None, None, () => (), "/webhook")
+    Seq(
+      Event(
+        description = "one message",
+        input = genericEventInput(oneMessage),
+        expectedOutput = ExpectedOutput(
+          slackMessage = Some(SlackMessage(slackMsg(oneMessageText), "/webhook"))
+        )
+      ),
+      Event(
+        description = "two messages",
+        input = genericEventInput(twoMessages),
+        expectedOutput = ExpectedOutput(
+          slackMessage = Some(SlackMessage(slackMsg(twoMessagesText), "/webhook"))
+        )
+      )
     )
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaIntegrationSpec.scala
@@ -34,7 +34,7 @@ trait LambdaIntegrationSpec extends LambdaSpecUtils {
             stubContext()
             val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
             new Lambda().process(stream, null)
-            wiremockSlackServer.verify(message.body.size,
+            wiremockSlackServer.verify(1,
               postRequestedFor(urlEqualTo(message.webhookUrl))
                 .withRequestBody(equalToJson(message.body))
             )

--- a/src/test/scala/uk/gov/nationalarchives/notifications/StepFunctionErrorIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/StepFunctionErrorIntegrationSpec.scala
@@ -10,15 +10,28 @@ import uk.gov.nationalarchives.notifications.decoders.StepFunctionErrorDecoder.S
 import java.util.UUID
 
 class StepFunctionErrorIntegrationSpec extends LambdaIntegrationSpec {
-  override lazy val events: TableFor8[String, String, Option[String], Option[String], Option[SqsExpectedMessageDetails], Option[SnsExpectedMessageDetails], () => Unit, String] = Table(
-    ("description", "input", "emailBody", "slackBody", "sqsMessage", "snsMessage", "stubContext", "slackUrl"),
-    ("a step function error on intg",
-      stepFunctionErrorInput(stepFunctionError("intg")), None, None, None, None, () => (), "/webhook"),
-    ("a step function error on staging",
-      stepFunctionErrorInput(stepFunctionError("staging")), None, slackMessage(stepFunctionError("staging")), None, None, () => (), "/webhook"),
-    ("a step function error on prod",
-      stepFunctionErrorInput(stepFunctionError("prod")), None, slackMessage(stepFunctionError("prod")), None, None, () => (), "/webhook"),
+  override lazy val events: Seq[Event] = Seq(
+    Event(
+      description = "a step function error on intg",
+      input = stepFunctionErrorInput(stepFunctionError("intg")),
+      expectedOutput = ExpectedOutput()
+    ),
+    Event(
+      description = "a step function error on staging",
+      input = stepFunctionErrorInput(stepFunctionError("staging")),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(slackMessage(stepFunctionError("staging")).get, "/webhook"))
+      )
+    ),
+    Event(
+      description = "a step function error on prod",
+      input = stepFunctionErrorInput(stepFunctionError("prod")),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(slackMessage(stepFunctionError("prod")).get, "/webhook"))
+      )
+    )
   )
+
 
   def stepFunctionError(environment: String): StepFunctionError = {
     val id = UUID.fromString("49d364ab-8bc3-4c53-90ca-d3f003179cb9")


### PR DESCRIPTION
- Encapsulate test events in case classes
- Specify defaults for different expected output types (`None` for `Optional`s, noop for stub context)