### PR TITLE
Remove GOVUK notify on toggle

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -45,8 +45,6 @@ s3 {
 }
 gov_uk_notify {
   endpoint = "https://api.notifications.service.gov.uk"
-  on = false
-  on = ${?SEND_GOV_UK_NOTIFICATIONS}
   api_key = "arbitrary_placeholder"
   api_key = ${?GOV_UK_NOTIFY_API_KEY}
   transfer_complete_template_id = "arbitrary_placeholder"

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -249,64 +249,59 @@ object EventMessages {
   implicit val transferCompleteEventMessages: Messages[TransferCompleteEvent, Unit] = new Messages[TransferCompleteEvent, Unit] {
     override def context(event: TransferCompleteEvent): IO[Unit] = IO.unit
     override def govUkNotifyEmail(transferCompleteEvent: TransferCompleteEvent, context: Unit): Option[GovUKEmailDetails] = {
-      if (eventConfig("gov_uk_notify.on").toBoolean) {
-        Some(
-          GovUKEmailDetails(
-            templateId = eventConfig("gov_uk_notify.transfer_complete_template_id"),
-            userEmail = eventConfig("tdr_inbox_email_address"),
-            personalisation = Map(
-              "userEmail" -> transferCompleteEvent.userEmail,
-              "userId" -> transferCompleteEvent.userId,
-              "transferringBodyName" -> transferCompleteEvent.transferringBodyName,
-              "consignmentId" -> transferCompleteEvent.consignmentId,
-              "consignmentReference" -> transferCompleteEvent.consignmentReference,
-              "seriesName" -> transferCompleteEvent.seriesName
-            ),
-            reference = s"${transferCompleteEvent.consignmentReference}-${transferCompleteEvent.userId}"
-          )
+      Some(
+        GovUKEmailDetails(
+          templateId = eventConfig("gov_uk_notify.transfer_complete_template_id"),
+          userEmail = eventConfig("tdr_inbox_email_address"),
+          personalisation = Map(
+            "userEmail" -> transferCompleteEvent.userEmail,
+            "userId" -> transferCompleteEvent.userId,
+            "transferringBodyName" -> transferCompleteEvent.transferringBodyName,
+            "consignmentId" -> transferCompleteEvent.consignmentId,
+            "consignmentReference" -> transferCompleteEvent.consignmentReference,
+            "seriesName" -> transferCompleteEvent.seriesName
+          ),
+          reference = s"${transferCompleteEvent.consignmentReference}-${transferCompleteEvent.userId}"
         )
-      } else None
+      )
     }
   }
 
   implicit val metadataReviewRequestEventMessages: Messages[MetadataReviewRequestEvent, Unit] = new Messages[MetadataReviewRequestEvent, Unit] {
     override def context(event: MetadataReviewRequestEvent): IO[Unit] = IO.unit
     override def govUkNotifyEmail(metadataReviewRequestEvent: MetadataReviewRequestEvent, context: Unit): Option[GovUKEmailDetails] = {
-      if (eventConfig("gov_uk_notify.on").toBoolean) {
-        Some(
-          GovUKEmailDetails(
-            templateId = eventConfig("gov_uk_notify.metadata_review_template_id"),
-            userEmail = eventConfig("tdr_inbox_email_address"),
-            personalisation = Map(
-              "userEmail" -> metadataReviewRequestEvent.userEmail,
-              "userId" -> metadataReviewRequestEvent.userId,
-              "consignmentId" -> metadataReviewRequestEvent.consignmentId,
-              "transferringBodyName" -> metadataReviewRequestEvent.transferringBodyName,
-              "consignmentReference" -> metadataReviewRequestEvent.consignmentReference,
-            ),
-            reference = s"${metadataReviewRequestEvent.consignmentReference}"
-          )
+      Some(
+        GovUKEmailDetails(
+          templateId = eventConfig("gov_uk_notify.metadata_review_template_id"),
+          userEmail = eventConfig("tdr_inbox_email_address"),
+          personalisation = Map(
+            "userEmail" -> metadataReviewRequestEvent.userEmail,
+            "userId" -> metadataReviewRequestEvent.userId,
+            "consignmentId" -> metadataReviewRequestEvent.consignmentId,
+            "transferringBodyName" -> metadataReviewRequestEvent.transferringBodyName,
+            "consignmentReference" -> metadataReviewRequestEvent.consignmentReference,
+          ),
+          reference = s"${metadataReviewRequestEvent.consignmentReference}"
         )
-      } else None
+      )
     }
   }
 
   implicit val metadataReviewSubmittedEventMessages: Messages[MetadataReviewSubmittedEvent, Unit] = new Messages[MetadataReviewSubmittedEvent, Unit] {
     override def context(event: MetadataReviewSubmittedEvent): IO[Unit] = IO.unit
+
     override def govUkNotifyEmail(metadataReviewSubmittedEvent: MetadataReviewSubmittedEvent, context: Unit): Option[GovUKEmailDetails] = {
-      if (eventConfig("gov_uk_notify.on").toBoolean) {
-        Some(
-          GovUKEmailDetails(
-            templateId = eventConfig("gov_uk_notify.metadata_review_submitted_template_id"),
-            userEmail = config.getString("tdr_inbox_email_address"),
-            personalisation = Map(
-              "consignmentReference" -> metadataReviewSubmittedEvent.consignmentReference,
-              "urlLink" -> metadataReviewSubmittedEvent.urlLink,
-            ),
-            reference = s"${metadataReviewSubmittedEvent.consignmentReference}"
-          )
+      Some(
+        GovUKEmailDetails(
+          templateId = eventConfig("gov_uk_notify.metadata_review_submitted_template_id"),
+          userEmail = config.getString("tdr_inbox_email_address"),
+          personalisation = Map(
+            "consignmentReference" -> metadataReviewSubmittedEvent.consignmentReference,
+            "urlLink" -> metadataReviewSubmittedEvent.urlLink,
+          ),
+          reference = s"${metadataReviewSubmittedEvent.consignmentReference}"
         )
-      } else None
+      )
     }
   }
 

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/Messages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/Messages.scala
@@ -45,7 +45,6 @@ object Messages {
     "slack.webhook.tdr_url",
     "slack.webhook.export_url",
     "sns.topic.da_event_bus_arn",
-    "gov_uk_notify.on",
     "gov_uk_notify.api_key",
     "gov_uk_notify.transfer_complete_template_id",
     "gov_uk_notify.metadata_review_template_id",

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -43,7 +43,6 @@ s3 {
 gov_uk_notify {
   transfer_complete_template_id = "VGVzdFRlbXBsYXRlSWQ=" # Base 64 decodes to this value TestTemplateId
   api_key = "c29tZV9hcGlfc2VjcmV0X2tleV9mb3JfZW52aXJvbm1lbnQ=" # Base 64 decodes to this value some_api_secret_key_for_environment
-  on = "dHJ1ZQ==" # Base 64 decodes to this value true
   endpoint = "http://localhost:9006"
   metadata_review_template_id = "VGVzdFRlbXBsYXRlSWQ=" # Base 64 decodes to this value TestTemplateId
   metadata_review_submitted_template_id = "VGVzdFRlbXBsYXRlSWQ=" # Base 64 decodes to this value TestTemplateId


### PR DESCRIPTION
For internal emails, we now send to a dedicated `tdrtest` inbox (#370).

Transferring body user emails will only send if the recipient is a team member in the GOVUK testing environment.