### PR TITLE
Tdrd 439 handle unexpected errors in tdr draft metadata validator lambda

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
@@ -37,7 +37,7 @@ class Lambda {
       case transferCompleteEvent: TransferCompleteEvent               => sendMessages(transferCompleteEvent)
       case metadataReviewRequestEvent: MetadataReviewRequestEvent     => sendMessages(metadataReviewRequestEvent)
       case metadataReviewSubmittedEvent: MetadataReviewSubmittedEvent => sendMessages(metadataReviewSubmittedEvent)
-      case draftMetadataStepFunctionEvent:DraftMetadataStepFunctionError => sendMessages(draftMetadataStepFunctionEvent)
+      case draftMetadataStepFunctionError:DraftMetadataStepFunctionError => sendMessages(draftMetadataStepFunctionError)
     }).flatten
       .unsafeRunSync()
   }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
@@ -5,6 +5,7 @@ import cats.effect._
 import cats.effect.unsafe.implicits.global
 import io.circe.parser.decode
 import uk.gov.nationalarchives.notifications.decoders.CloudwatchAlarmDecoder.CloudwatchAlarmEvent
+import uk.gov.nationalarchives.notifications.decoders.DraftMetadataStepFunctionErrorDecoder.DraftMetadataStepFunctionError
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportStatusEvent
 import uk.gov.nationalarchives.notifications.decoders.GenericMessageDecoder.GenericMessagesEvent
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
@@ -24,16 +25,17 @@ class Lambda {
   def process(input: InputStream, output: OutputStream): String = {
     val inputString = Source.fromInputStream(input).mkString
     IO.fromEither(decode[IncomingEvent](inputString).map {
-      case scan: ScanEvent                                            => sendMessages(scan)
-      case exportStatus: ExportStatusEvent                            => sendMessages(exportStatus)
-      case keycloakEvent: KeycloakEvent                               => sendMessages(keycloakEvent)
-      case genericMessagesEvent: GenericMessagesEvent                 => sendMessages(genericMessagesEvent)
-      case cloudwatchAlarmEvent: CloudwatchAlarmEvent                 => sendMessages(cloudwatchAlarmEvent)
-      case parameterStoreExpiryEvent: ParameterStoreExpiryEvent       => sendMessages(parameterStoreExpiryEvent)
-      case stepFunctionError: StepFunctionError                       => sendMessages(stepFunctionError)
-      case transferCompleteEvent: TransferCompleteEvent               => sendMessages(transferCompleteEvent)
-      case metadataReviewRequestEvent: MetadataReviewRequestEvent     => sendMessages(metadataReviewRequestEvent)
-      case metadataReviewSubmittedEvent: MetadataReviewSubmittedEvent => sendMessages(metadataReviewSubmittedEvent)
+      case scan: ScanEvent                                               => sendMessages(scan)
+      case exportStatus: ExportStatusEvent                               => sendMessages(exportStatus)
+      case keycloakEvent: KeycloakEvent                                  => sendMessages(keycloakEvent)
+      case genericMessagesEvent: GenericMessagesEvent                    => sendMessages(genericMessagesEvent)
+      case cloudwatchAlarmEvent: CloudwatchAlarmEvent                    => sendMessages(cloudwatchAlarmEvent)
+      case parameterStoreExpiryEvent: ParameterStoreExpiryEvent          => sendMessages(parameterStoreExpiryEvent)
+      case stepFunctionError: StepFunctionError                          => sendMessages(stepFunctionError)
+      case transferCompleteEvent: TransferCompleteEvent                  => sendMessages(transferCompleteEvent)
+      case metadataReviewRequestEvent: MetadataReviewRequestEvent        => sendMessages(metadataReviewRequestEvent)
+      case metadataReviewSubmittedEvent: MetadataReviewSubmittedEvent    => sendMessages(metadataReviewSubmittedEvent)
+      case draftMetadataStepFunctionEvent:DraftMetadataStepFunctionError => sendMessages(draftMetadataStepFunctionEvent)
     }).flatten
       .unsafeRunSync()
   }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/DraftMetadataStepFunctionErrorDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/DraftMetadataStepFunctionErrorDecoder.scala
@@ -1,0 +1,16 @@
+package uk.gov.nationalarchives.notifications.decoders
+
+import io.circe.{Decoder, HCursor}
+
+import java.util.UUID
+
+object DraftMetadataStepFunctionErrorDecoder {
+  case class DraftMetadataStepFunctionError(consignmentId: UUID, metaDataError: String, cause: String, environment: String) extends IncomingEvent
+
+  val decodeMetadataStepFunctionError: Decoder[IncomingEvent] = (c: HCursor) => for {
+    metaDataError <- c.downField("metaDataError").as[String]
+    cause <- c.downField("cause").as[String]
+    environment <- c.downField("environment").as[String]
+    consignmentId <- c.downField("consignmentId").as[UUID]
+  } yield DraftMetadataStepFunctionError(consignmentId, metaDataError, cause, environment)
+}

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
@@ -5,6 +5,7 @@ import io.circe.generic.auto._
 import io.circe.parser.parse
 import io.circe.{Decoder, DecodingFailure, HCursor, Json}
 import uk.gov.nationalarchives.notifications.decoders.CloudwatchAlarmDecoder.CloudwatchAlarmEvent
+import uk.gov.nationalarchives.notifications.decoders.DraftMetadataStepFunctionErrorDecoder.decodeMetadataStepFunctionError
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportStatusEvent
 import uk.gov.nationalarchives.notifications.decoders.GenericMessageDecoder.GenericMessagesEvent
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
@@ -20,7 +21,8 @@ trait IncomingEvent {}
 object IncomingEvent {
   implicit val allDecoders: Decoder[IncomingEvent] = decodeScanEvent or decodeSnsEvent[ExportStatusEvent] or
     decodeSnsEvent[KeycloakEvent] or decodeSnsEvent[GenericMessagesEvent] or
-    decodeSnsEvent[CloudwatchAlarmEvent] or decodeSnsEvent[ParameterStoreExpiryEvent] or decodeStepFunctionError or decodeSnsEvent[TransferCompleteEvent] or decodeSnsEvent[MetadataReviewRequestEvent] or decodeSnsEvent[MetadataReviewSubmittedEvent]
+    decodeSnsEvent[CloudwatchAlarmEvent] or decodeSnsEvent[ParameterStoreExpiryEvent] or decodeStepFunctionError or decodeSnsEvent[TransferCompleteEvent] or
+    decodeSnsEvent[MetadataReviewRequestEvent] or decodeSnsEvent[MetadataReviewSubmittedEvent] or decodeMetadataStepFunctionError
 
   def decodeSnsEvent[T <: IncomingEvent]()(implicit decoder: Decoder[T]): Decoder[IncomingEvent] = (c: HCursor) => for {
     messages <- c.downField("Records").as[List[SnsRecord]]

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -18,6 +18,7 @@ import uk.gov.nationalarchives.common.messages.Properties
 import uk.gov.nationalarchives.da.messages.bag.available
 import uk.gov.nationalarchives.da.messages.bag.available.{BagAvailable, ConsignmentType}
 import uk.gov.nationalarchives.notifications.decoders.CloudwatchAlarmDecoder.CloudwatchAlarmEvent
+import uk.gov.nationalarchives.notifications.decoders.DraftMetadataStepFunctionErrorDecoder.DraftMetadataStepFunctionError
 import uk.gov.nationalarchives.notifications.decoders.ExportNotificationDecoder._
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportStatusEvent
 import uk.gov.nationalarchives.notifications.decoders.GenericMessageDecoder.GenericMessagesEvent
@@ -366,6 +367,27 @@ object EventMessages {
           s"*Environment* ${incomingEvent.environment}",
           s"*Cause*: ${incomingEvent.cause}",
           s"*Error*: ${incomingEvent.error}"
+        )
+        SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", messageList.mkString("\n"))))).some
+      } else {
+        None
+      }
+    }
+  }
+
+  implicit val draftMetadataStepFunctionErrorMessages: Messages[DraftMetadataStepFunctionError, Unit] = new Messages[DraftMetadataStepFunctionError, Unit] {
+    override def context(incomingEvent: DraftMetadataStepFunctionError): IO[Unit] = IO.unit
+
+    override def email(incomingEvent: DraftMetadataStepFunctionError, context: Unit): Option[Email] = None
+
+    override def slack(incomingEvent: DraftMetadataStepFunctionError, context: Unit): Option[SlackMessage] = {
+      if(incomingEvent.environment == "prod") {
+         val messageList = List(
+          ":warning: *DraftMetadata upload has failed for consignment*",
+          s"*ConsignmentId* ${incomingEvent.consignmentId}",
+          s"*Environment* ${incomingEvent.environment}",
+          s"*Cause*: ${incomingEvent.cause}",
+          s"*Error*: ${incomingEvent.metaDataError}"
         )
         SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", messageList.mkString("\n"))))).some
       } else {

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/Messages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/Messages.scala
@@ -12,6 +12,7 @@ import uk.gov.nationalarchives.aws.utils.kms.KMSClients.kms
 import uk.gov.nationalarchives.aws.utils.kms._
 import uk.gov.nationalarchives.aws.utils.ses._
 import uk.gov.nationalarchives.aws.utils.sns._
+import uk.gov.nationalarchives.notifications.decoders.DraftMetadataStepFunctionErrorDecoder.DraftMetadataStepFunctionError
 import uk.gov.nationalarchives.notifications.decoders.ExportStatusDecoder.ExportStatusEvent
 import uk.gov.nationalarchives.notifications.decoders.IncomingEvent
 import uk.gov.nationalarchives.notifications.decoders.KeycloakEventDecoder.KeycloakEvent
@@ -134,6 +135,7 @@ object Messages {
         val failureEscalationUrl = Option.when(ev.environment == "prod" && !ev.success)(eventConfig("slack.webhook.tdr_url"))
         Seq(Some(eventConfig("slack.webhook.export_url")), failureEscalationUrl).flatten
       case _: KeycloakEvent => Seq(eventConfig("slack.webhook.tdr_url"))
+      case _: DraftMetadataStepFunctionError => Seq(eventConfig("slack.webhook.tdr_url"))
       case _                => Seq(eventConfig("slack.webhook.url"))
     }
   }

--- a/src/test/scala/uk/gov/nationalarchives/notifications/DraftMetadataStepFunctionErrorIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/DraftMetadataStepFunctionErrorIntegrationSpec.scala
@@ -1,0 +1,55 @@
+package uk.gov.nationalarchives.notifications
+
+import io.circe.Printer
+import io.circe.generic.auto._
+import io.circe.syntax._
+import uk.gov.nationalarchives.notifications.decoders.DraftMetadataStepFunctionErrorDecoder.DraftMetadataStepFunctionError
+
+import java.util.UUID
+
+class DraftMetadataStepFunctionErrorIntegrationSpec extends LambdaIntegrationSpec {
+  override lazy val events: Seq[Event] = Seq(
+    Event(
+      description = "a draft metadata step function error on intg",
+      input = draftMetaDataStepFunctionErrorInput(draftMetadataStepFunctionError("intg")),
+      expectedOutput = ExpectedOutput()
+    ),
+    Event(
+      description = "a draft metadata step function error on staging",
+      input = draftMetaDataStepFunctionErrorInput(draftMetadataStepFunctionError("staging")),
+      expectedOutput = ExpectedOutput()
+    ),
+    Event(
+      description = "a draft metadata step function error on prod",
+      input = draftMetaDataStepFunctionErrorInput(draftMetadataStepFunctionError("prod")),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(slackMessage(draftMetadataStepFunctionError("prod")).get, "/webhook"))
+      )
+    )
+  )
+
+
+  def draftMetadataStepFunctionError(environment: String): DraftMetadataStepFunctionError = {
+    val id = UUID.fromString("49d364ab-8bc3-4c53-90ca-d3f003179cb9")
+    DraftMetadataStepFunctionError(id, "error", "cause", environment)
+  }
+
+  def draftMetaDataStepFunctionErrorInput(draftMetadataStepFunctionError: DraftMetadataStepFunctionError): String = {
+    draftMetadataStepFunctionError.asJson.printWith(Printer.noSpaces)
+  }
+
+  def slackMessage(draftMetadataStepFunctionError: DraftMetadataStepFunctionError): Option[String] = Option {
+    s"""{
+       |  "blocks": [
+       |    {
+       |      "type": "section",
+       |      "text": {
+       |        "type": "mrkdwn",
+       |        "text": ":warning: *DraftMetadata upload has failed for consignment*\\n*ConsignmentId* ${draftMetadataStepFunctionError.consignmentId}\\n*Environment* ${draftMetadataStepFunctionError.environment}\\n*Cause*: ${draftMetadataStepFunctionError.cause}\\n*Error*: ${draftMetadataStepFunctionError.metaDataError}"
+       |      }
+       |    }
+       |  ]
+       |}
+       |""".stripMargin
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/notifications/DraftMetadataStepFunctionErrorIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/DraftMetadataStepFunctionErrorIntegrationSpec.scala
@@ -23,7 +23,7 @@ class DraftMetadataStepFunctionErrorIntegrationSpec extends LambdaIntegrationSpe
       description = "a draft metadata step function error on prod",
       input = draftMetaDataStepFunctionErrorInput(draftMetadataStepFunctionError("prod")),
       expectedOutput = ExpectedOutput(
-        slackMessage = Some(SlackMessage(slackMessage(draftMetadataStepFunctionError("prod")).get, "/webhook"))
+        slackMessage = Some(SlackMessage(slackMessage(draftMetadataStepFunctionError("prod")).get, "/webhook-tdr"))
       )
     )
   )


### PR DESCRIPTION
If an unexpected error occurs during the handling of the request in the DraftMetadataValidator lambda the error is handled an the reason is returned to the calling code (Draft metadata step function). An error will be surfaced to the user in the UI but to allow the team to be proactive in resolving bugs, this error that should never happen will be sent to the TDR slack if it is seen in production.  