### PR TITLE
Turn off email alerts for ECR scan events

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project is for sending slack/email/SQS messages in response to events. It supports several types of event:
 
 * ECR scan results. Each time there is an ECR repository scan, the scan results are checked. If there are any errors, a
-  Slack.
+  Slack message is sent.
 * Consignment export results. When the consignment export task finishes, a Slack message is sent with details of whether
   the export succeeded or failed. A message is also sent, to a Digital Archiving SNS topic for other Digital Archiving services to pick up and act upon.
 * Generic message event. This allows a service to send message text which is sent directly to Slack with no other processing.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project is for sending slack/email/SQS messages in response to events. It supports several types of event:
 
 * ECR scan results. Each time there is an ECR repository scan, the scan results are checked. If there are any errors, a
-  Slack and email message is sent.
+  Slack.
 * Consignment export results. When the consignment export task finishes, a Slack message is sent with details of whether
   the export succeeded or failed. A message is also sent, to a Digital Archiving SNS topic for other Digital Archiving services to pick up and act upon.
 * Generic message event. This allows a service to send message text which is sent directly to Slack with no other processing.

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -7,7 +7,6 @@ import com.typesafe.scalalogging.Logger
 import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.syntax.EncoderOps
-import scalatags.Text.all._
 import software.amazon.awssdk.services.ecr.model.FindingSeverity
 import uk.gov.nationalarchives.aws.utils.ecr.ECRClients.ecr
 import uk.gov.nationalarchives.aws.utils.ecr.ECRUtils
@@ -140,28 +139,8 @@ object EventMessages {
     }
 
     override def email(event: ScanEvent, report: ImageScanReport): Option[SESUtils.Email] = {
-      val detail = event.detail
-      val filteredReport = filterReport(report)
-      if (shouldSendEmailNotification(detail, filteredReport.findings)) {
-        val message = html(
-          body(
-            h1(s"Image scan results for ${detail.repositoryName}"),
-            div(
-              p(s"${filteredReport.criticalCount} critical vulnerabilities"),
-              p(s"${filteredReport.highCount} high vulnerabilities"),
-              p(s"${filteredReport.mediumCount} medium vulnerabilities"),
-              p(s"${filteredReport.lowCount} low vulnerabilities"),
-              p(s"${filteredReport.undefinedCount} undefined vulnerabilities")
-            ),
-            div(
-              p(ecrScanDocumentationMessage)
-            )
-          )
-        ).toString()
-        Email("scanresults@tdr-management.nationalarchives.gov.uk", eventConfig("ses.email.to"), s"ECR scan results for ${detail.repositoryName}", message).some
-      } else {
-        Option.empty
-      }
+      logger.info(s"Skipping email for ECR scan vulnerabilities: ${event.detail.repositoryName}")
+      Option.empty
     }
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
@@ -9,31 +9,6 @@ import scala.io.Source
 class LambdaErrorSpec extends LambdaSpecUtils with MockEcrApi {
 
   private val highSeverityEcrApiResponse = Source.fromResource("ecr-findings/high-severity.json").getLines.mkString
-  private val mediumSeverityEcrApiResponse = Source.fromResource("ecr-findings/medium-severity.json").getLines.mkString
-
-  "the process method" should "error if the ses service is unavailable" in {
-    ecrApiEndpoint.stubFor(post(urlEqualTo("/"))
-      .willReturn(ok(highSeverityEcrApiResponse)))
-
-    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000, 1, 10)))
-    val stream = new java.io.ByteArrayInputStream(scanEventInputText(scanEvent).getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
-    wiremockSesEndpoint.resetAll()
-    val exception = intercept[Exception] {
-      new Lambda().process(stream, null)
-    }
-    exception.getMessage should be("null (Service: Ses, Status Code: 404, Request ID: null)")
-  }
-
-  "the process method" should "not error if the ses service is unavailable for a medium severity event" in {
-    ecrApiEndpoint.stubFor(post(urlEqualTo("/"))
-      .willReturn(ok(mediumSeverityEcrApiResponse)))
-
-    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000, 1, 10)))
-    val stream = new java.io.ByteArrayInputStream(scanEventInputText(scanEvent).getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
-    wiremockSesEndpoint.resetAll()
-    val response = new Lambda().process(stream, null)
-    response should equal("")
-  }
 
   "the process method" should "error if the slack service is unavailable" in {
     ecrApiEndpoint.stubFor(post(urlEqualTo("/"))


### PR DESCRIPTION
These are no longer relevant with the implementation of Wiz to provide details of vulnerabilities to a wider audience