### PR TITLE
Configure upload event notifications

### DIFF
--- a/src/main/resources/application.intg.conf
+++ b/src/main/resources/application.intg.conf
@@ -12,4 +12,6 @@ gov_uk_notify {
   metadata_review_requested_tb_template_id = "65d75e74-51f3-4aff-ac9d-17bf8dc16db8"
   metadata_review_rejected_template_id = "e1a7f030-fa60-4a80-9b7a-10fca3f4ebfa"
   metadata_review_approved_template_id = "445a01dc-8c8f-4b67-9ca7-f9cb6d039007"
+  upload_failed_template_id = "977f7665-a447-4a3d-982c-e0a9dc5f78be"
+  upload_complete_template_id = "0f654da3-11c9-4bb7-8c2f-c906e106102c"
 }

--- a/src/main/resources/application.prod.conf
+++ b/src/main/resources/application.prod.conf
@@ -12,4 +12,6 @@ gov_uk_notify {
   metadata_review_requested_tb_template_id = "8752957b-b46e-4c85-841f-734c0a0c077c"
   metadata_review_rejected_template_id = "88e82b68-3535-4ca3-b5a3-94d986880f05"
   metadata_review_approved_template_id = "312f89bd-c623-4914-a346-f39836a27354"
+  upload_failed_template_id = "placeholder"
+  upload_complete_template_id = "placeholder"
 }

--- a/src/main/resources/application.staging.conf
+++ b/src/main/resources/application.staging.conf
@@ -12,4 +12,6 @@ gov_uk_notify {
   metadata_review_requested_tb_template_id = "168da882-5d93-40a8-a0e1-1cd069350282"
   metadata_review_rejected_template_id = "2cbfd724-22f0-4efc-a476-03e62e515615"
   metadata_review_approved_template_id = "8d0ff7d3-b79e-4efe-91d8-7b8da50ce521"
+  upload_failed_template_id = "placeholder"
+  upload_complete_template_id = "placeholder"
 }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/Lambda.scala
@@ -16,6 +16,7 @@ import uk.gov.nationalarchives.notifications.decoders.ParameterStoreExpiryEventD
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.ScanEvent
 import uk.gov.nationalarchives.notifications.decoders.StepFunctionErrorDecoder.StepFunctionError
 import uk.gov.nationalarchives.notifications.decoders.TransferCompleteEventDecoder.TransferCompleteEvent
+import uk.gov.nationalarchives.notifications.decoders.UploadEventDecoder.UploadEvent
 import uk.gov.nationalarchives.notifications.decoders._
 import uk.gov.nationalarchives.notifications.messages.EventMessages._
 import uk.gov.nationalarchives.notifications.messages.Messages._
@@ -26,18 +27,19 @@ class Lambda {
   def process(input: InputStream, output: OutputStream): String = {
     val inputString = Source.fromInputStream(input).mkString
     IO.fromEither(decode[IncomingEvent](inputString).map {
-      case scan: ScanEvent                                            => sendMessages(scan)
-      case exportStatus: ExportStatusEvent                            => sendMessages(exportStatus)
-      case keycloakEvent: KeycloakEvent                               => sendMessages(keycloakEvent)
-      case genericMessagesEvent: GenericMessagesEvent                 => sendMessages(genericMessagesEvent)
-      case cloudwatchAlarmEvent: CloudwatchAlarmEvent                 => sendMessages(cloudwatchAlarmEvent)
-      case parameterStoreExpiryEvent: ParameterStoreExpiryEvent       => sendMessages(parameterStoreExpiryEvent)
-      case malwareScanNotificationEvent: MalwareScanThreatFoundEvent  => sendMessages(malwareScanNotificationEvent)
-      case stepFunctionError: StepFunctionError                       => sendMessages(stepFunctionError)
-      case transferCompleteEvent: TransferCompleteEvent               => sendMessages(transferCompleteEvent)
-      case metadataReviewRequestEvent: MetadataReviewRequestEvent     => sendMessages(metadataReviewRequestEvent)
-      case metadataReviewSubmittedEvent: MetadataReviewSubmittedEvent => sendMessages(metadataReviewSubmittedEvent)
+      case scan: ScanEvent                                               => sendMessages(scan)
+      case exportStatus: ExportStatusEvent                               => sendMessages(exportStatus)
+      case keycloakEvent: KeycloakEvent                                  => sendMessages(keycloakEvent)
+      case genericMessagesEvent: GenericMessagesEvent                    => sendMessages(genericMessagesEvent)
+      case cloudwatchAlarmEvent: CloudwatchAlarmEvent                    => sendMessages(cloudwatchAlarmEvent)
+      case parameterStoreExpiryEvent: ParameterStoreExpiryEvent          => sendMessages(parameterStoreExpiryEvent)
+      case malwareScanNotificationEvent: MalwareScanThreatFoundEvent     => sendMessages(malwareScanNotificationEvent)
+      case stepFunctionError: StepFunctionError                          => sendMessages(stepFunctionError)
+      case transferCompleteEvent: TransferCompleteEvent                  => sendMessages(transferCompleteEvent)
+      case metadataReviewRequestEvent: MetadataReviewRequestEvent        => sendMessages(metadataReviewRequestEvent)
+      case metadataReviewSubmittedEvent: MetadataReviewSubmittedEvent    => sendMessages(metadataReviewSubmittedEvent)
       case draftMetadataStepFunctionError:DraftMetadataStepFunctionError => sendMessages(draftMetadataStepFunctionError)
+      case uploadEvent: UploadEvent                                      => sendMessages(uploadEvent)
     }).flatten
       .unsafeRunSync()
   }

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/IncomingEvent.scala
@@ -16,6 +16,7 @@ import uk.gov.nationalarchives.notifications.decoders.ParameterStoreExpiryEventD
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.decodeScanEvent
 import uk.gov.nationalarchives.notifications.decoders.StepFunctionErrorDecoder.decodeStepFunctionError
 import uk.gov.nationalarchives.notifications.decoders.TransferCompleteEventDecoder.TransferCompleteEvent
+import uk.gov.nationalarchives.notifications.decoders.UploadEventDecoder.UploadEvent
 
 trait IncomingEvent {}
 
@@ -23,7 +24,8 @@ object IncomingEvent {
   implicit val allDecoders: Decoder[IncomingEvent] = decodeScanEvent or decodeSnsEvent[ExportStatusEvent] or
     decodeSnsEvent[KeycloakEvent] or decodeSnsEvent[GenericMessagesEvent] or
     decodeSnsEvent[CloudwatchAlarmEvent] or decodeSnsEvent[ParameterStoreExpiryEvent] or decodeStepFunctionError or decodeSnsEvent[TransferCompleteEvent] or
-    decodeSnsEvent[MetadataReviewRequestEvent] or decodeSnsEvent[MetadataReviewSubmittedEvent] or decodeSnsEvent[DraftMetadataStepFunctionError]  or decodeSnsEvent[MalwareScanThreatFoundEvent]
+    decodeSnsEvent[MetadataReviewRequestEvent] or decodeSnsEvent[MetadataReviewSubmittedEvent] or decodeSnsEvent[DraftMetadataStepFunctionError] or decodeSnsEvent[MalwareScanThreatFoundEvent] or
+    decodeSnsEvent[UploadEvent]
 
   def decodeSnsEvent[T <: IncomingEvent]()(implicit decoder: Decoder[T]): Decoder[IncomingEvent] = (c: HCursor) => for {
     messages <- c.downField("Records").as[List[SnsRecord]]

--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/UploadEventDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/UploadEventDecoder.scala
@@ -1,0 +1,12 @@
+package uk.gov.nationalarchives.notifications.decoders
+
+object UploadEventDecoder {
+  case class UploadEvent(
+    transferringBodyName: String,
+    consignmentReference: String,
+    consignmentId: String,
+    status: String,
+    userId: String,
+    userEmail: String
+  ) extends IncomingEvent
+}

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/Messages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/Messages.scala
@@ -56,6 +56,8 @@ object Messages {
     "gov_uk_notify.metadata_review_requested_tb_template_id",
     "gov_uk_notify.metadata_review_rejected_template_id",
     "gov_uk_notify.metadata_review_approved_template_id",
+    "gov_uk_notify.upload_failed_template_id",
+    "gov_uk_notify.upload_complete_template_id",
     "tdr_inbox_email_address"
   ).flatMap { configName => 
     Try(config.getString(configName)).toOption

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -48,6 +48,8 @@ gov_uk_notify {
   metadata_review_approved_template_id = "VGVzdEFwcHJvdmVkVGVtcGxhdGVJZA==" # Base 64 decodes to this value TestApprovedTemplateId
   transfer_complete_dta_template_id = "VGVzdFRyYW5zZmVyRFRBVGVtcGxhdGVJZA==" # Base 64 decodes to this value TestTransferDTATemplateId
   transfer_complete_tb_template_id = "VGVzdFRyYW5zZmVyVEJUZW1wbGF0ZUlk" # Base 64 decodes to this value TestTransferTBTemplateId
+  upload_failed_template_id = "VGVzdFVwbG9hZEZhaWxlZFRlbXBsYXRlSWQ=" # Base 64 decodes to this value TestUploadFailedTemplateId
+  upload_complete_template_id = "VGVzdFVwbG9hZENvbXBsZXRlVGVtcGxhdGVJZA==" # Base 64 decodes to this value TestUploadCompleteTemplateId
   api_key = "c29tZV9hcGlfc2VjcmV0X2tleV9mb3JfZW52aXJvbm1lbnQ=" # Base 64 decodes to this value some_api_secret_key_for_environment
   external_emails_on = "dHJ1ZQ==" # Base 64 decodes to this value true
   endpoint = "http://localhost:9006"

--- a/src/test/scala/uk/gov/nationalarchives/notifications/UploadIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/UploadIntegrationSpec.scala
@@ -1,0 +1,83 @@
+package uk.gov.nationalarchives.notifications
+
+import uk.gov.nationalarchives.notifications.decoders.UploadEventDecoder.UploadEvent
+import uk.gov.nationalarchives.notifications.messages.EventMessages.GovUKEmailDetails
+
+class UploadIntegrationSpec extends LambdaIntegrationSpec {
+  override lazy val events: Seq[Event] = Seq(
+    Event(
+      description = "A upload complete event",
+      input = uploadNotificationInputString(
+        UploadEvent(
+          transferringBodyName = "SomeTransferringBody",
+          consignmentReference = "SomeConsignmentReference",
+          consignmentId = "SomeConsignmentId",
+          userId = "SomeUserId",
+          userEmail = "test@test.test",
+          status = "Complete"
+        )
+      ),
+      stubContext = stubDummyGovUkNotifyEmailResponse,
+      expectedOutput = ExpectedOutput(
+        govUKEmail = Some(
+          GovUKEmailDetails(
+            reference = "SomeConsignmentReference-SomeUserId",
+            templateId = "TestUploadCompleteTemplateId",
+            userEmail = "test@test.test",
+            personalisation = Map(
+              "userEmail" -> "test@test.test",
+              "userId" -> "SomeUserId",
+              "transferringBodyName" -> "SomeTransferringBody",
+              "consignmentId" -> "SomeConsignmentId",
+              "consignmentReference" -> "SomeConsignmentReference",
+              "status" -> "Complete"
+            )
+          )
+        )
+      )
+    ),
+    Event(
+      description = "An upload failed event",
+      input = uploadNotificationInputString(
+        UploadEvent(
+          transferringBodyName = "SomeTransferringBody",
+          consignmentReference = "SomeConsignmentReference",
+          consignmentId = "SomeConsignmentId",
+          status = "Failed",
+          userId = "SomeUserId",
+          userEmail = "test@test.test"
+        )
+      ),
+      stubContext = stubDummyGovUkNotifyEmailResponse,
+      expectedOutput = ExpectedOutput(
+        govUKEmail = Some(
+          GovUKEmailDetails(
+            reference = "SomeConsignmentReference-SomeUserId",
+            templateId = "TestUploadFailedTemplateId",
+            userEmail = "test@test.test",
+            personalisation = Map(
+              "userEmail" -> "test@test.test",
+              "userId" -> "SomeUserId",
+              "transferringBodyName" -> "SomeTransferringBody",
+              "consignmentId" -> "SomeConsignmentId",
+              "consignmentReference" -> "SomeConsignmentReference",
+              "status" -> "Failed"
+            )
+          )
+        )
+      )
+    )
+  )
+  
+  def uploadNotificationInputString(uploadEvent: UploadEvent): String = {
+    import uploadEvent._
+    s"""{
+       | "Records": [
+       |   {
+       |     "Sns": {
+       |       "Message": "{\\"transferringBodyName\\":\\"$transferringBodyName\\",\\"consignmentReference\\":\\"$consignmentReference\\",\\"consignmentId\\" : \\"$consignmentId\\",\\"status\\" : \\"$status\\",\\"userId\\" : \\"$userId\\",\\"userEmail\\" : \\"$userEmail\\"}"
+       |      }
+       |    }
+       |  ]}""".stripMargin
+  }
+}


### PR DESCRIPTION
Support SharePoint transfers where upload is undertaken by non-TDR web application

Users require notification of upload complete/failed so can continue transfer within TDR web application

No system should be sending these event messages so safe to make use of "place holder" template ids