### PR TITLE
Limit error size

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   private val circeVersion = "0.14.15"
-  private val sttpClient3Version = "3.9.7"
+  private val sttpClient3Version = "3.11.0"
   private val awsUtilsVersion = "0.1.320"
   private val elasticMqVersion = "1.6.16"
   

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   private val circeVersion = "0.14.15"
-  private val sttpClient3Version = "3.9.7"
+  private val sttpClient3Version = "3.11.0"
   private val awsUtilsVersion = "0.1.319"
   private val elasticMqVersion = "1.6.16"
   

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -591,9 +591,9 @@ object EventMessages {
     }
   }
 
-  private def truncate(s: String, max: Int): String = Option(s).filter(_.nonEmpty).map { str =>
+  private def truncate(s: String, max: Int): String = Option(s).fold("") { str =>
     if (str.length <= max) str else str.take(max - 3) + "..."
-  }.getOrElse("")
+  }
 
   implicit val backendCheckFailureEventMessages: Messages[BackendCheckFailureEvent, Unit] = new Messages[BackendCheckFailureEvent, Unit] {
     override def context(event: BackendCheckFailureEvent): IO[Unit] = IO.unit

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -591,15 +591,21 @@ object EventMessages {
     }
   }
 
+  private def truncate(s: String, max: Int): String = Option(s).filter(_.nonEmpty).map { str =>
+    if (str.length <= max) str else str.take(max - 3) + "..."
+  }.getOrElse("")
+
   implicit val backendCheckFailureEventMessages: Messages[BackendCheckFailureEvent, Unit] = new Messages[BackendCheckFailureEvent, Unit] {
     override def context(event: BackendCheckFailureEvent): IO[Unit] = IO.unit
 
     override def slack(incomingEvent: BackendCheckFailureEvent, context: Unit): Option[SlackMessage] = {
+      val truncatedFailureCause = truncate(incomingEvent.failureCause, 50)
+
       val messageList = List(
         ":warning: *A user has experienced a step function Backend File Check Failure*",
         s"*Consignment ID*: ${incomingEvent.consignmentId}",
         s"*Environment*: ${incomingEvent.environment}",
-        s"*Failure Cause*: ${incomingEvent.failureCause}",
+        s"*Failure Cause*: $truncatedFailureCause",
         s"*Backend Checks Process*: ${incomingEvent.backEndChecksProcess}"
       )
       SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", messageList.mkString("\n"))))).some

--- a/src/test/scala/uk/gov/nationalarchives/notifications/BackendCheckFailureIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/BackendCheckFailureIntegrationSpec.scala
@@ -55,6 +55,40 @@ class BackendCheckFailureIntegrationSpec extends LambdaIntegrationSpec {
           )
         )
       )
+    ),
+    Event(
+      description = "A backend check failure event with failure cause exactly 50 chars",
+      input = backendCheckFailureInputString(
+        consignmentId = consignmentId,
+        environment = "prod",
+        failureCause = "A" * 50,
+        backEndChecksProcess = "SomeProcess"
+      ),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(
+          SlackMessage(
+            body = slackMessage(consignmentId, "prod", "A" * 50, "SomeProcess"),
+            webhookUrl = "/webhook-transfers"
+          )
+        )
+      )
+    ),
+    Event(
+      description = "A backend check failure event with failure cause exceeding 50 chars is truncated",
+      input = backendCheckFailureInputString(
+        consignmentId = consignmentId,
+        environment = "prod",
+        failureCause = "A" * 100,
+        backEndChecksProcess = "SomeProcess"
+      ),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(
+          SlackMessage(
+            body = slackMessage(consignmentId, "prod", "A" * 47 + "...", "SomeProcess"),
+            webhookUrl = "/webhook-transfers"
+          )
+        )
+      )
     )
   )
 


### PR DESCRIPTION
The error message for the step function could be too large for slack so need to truncate if it is added.
The error is not going to be passed until it is agreed, as it might allow sensitive data but truncation code if useful in case text sent is too large