### PR TITLE
truncate backend step function cause

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -436,11 +436,12 @@ object EventMessages {
 
     override def slack(incomingEvent: StepFunctionError, context: Unit): Option[SlackMessage] = {
       if (incomingEvent.environment != "intg") {
+        val truncatedCause = truncate(incomingEvent.cause, 50)
         val messageList = List(
           ":warning: *Backend checks failure for consignment*",
           s"*ConsignmentId* ${incomingEvent.consignmentId}",
           s"*Environment* ${incomingEvent.environment}",
-          s"*Cause*: ${incomingEvent.cause}",
+          s"*Cause*: $truncatedCause",
           s"*Error*: ${incomingEvent.error}"
         )
         SlackMessage(List(SlackBlock("section", SlackText("mrkdwn", messageList.mkString("\n"))))).some


### PR DESCRIPTION
backend check step function sent cause with too much data for slack  "Cause": "{\"errorMessage\":\"software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request: software.amazon.awssdk.http.SdkCancellationException: Subscriber cancelled before all events were published (SDK Attempt Count: 2)\",\"errorType\":\"java.util.concurrent.CompletionException\",\"stackTrace\":[\"software.amazon.awssdk.utils.CompletableFutureUtils.errorAsCompletionException(CompletableFutureUtils.java:64)\",\"software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncExecutionFailureExceptionReportingStage.lambda$execute$0(AsyncExecutionFailureExceptionReportingStage.java:51)\",\"java.base/java.util.concurrent.CompletableFuture.uniHandle(Unknown Source)\",\"java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(Unknown Source)\",\"java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)\",\"java.base/java.util.concurrent.CompletableFuture.completeExceptionally(Unknown Source)\",\"software.amazon.awssdk.utils.CompletableFutureUtils.lambda$forwardExceptionTo$0(CompletableFutureUtils.java:78)\",\"java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source)\",\"java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source)\",\"java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)\",\"java.base/java.util.concurrent.CompletableFuture.completeExceptionally(Unknown Source)\",\"software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncRetryableStage$RetryingExecutor.maybeAttemptExecute(AsyncRetryableStage.java:139)\",\"software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncRetryableStage$RetryingExecutor.maybeRetryExecute(AsyncRetryableStage.java:157)\",\"software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncRetryableStage$RetryingExecutor.lambda$attemptExecute$1(AsyncRetryableStage.java:117)\",\"java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source)\",\"java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown  .......