### PR TITLE
TDRD-1404 - Use optional for "finding-severity-counts" field

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ScanDecoder.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/decoders/ScanDecoder.scala
@@ -10,7 +10,8 @@ object ScanDecoder {
                          repositoryName: String,
                          tags: List[String],
                          imageDigest: String,
-                         findingSeverityCounts: ScanFindingCounts
+                         findingSeverityCounts: Option[ScanFindingCounts],
+                         scanStatus: String
                        )
 
   case class ScanFindingCounts(critical: Int, high: Int, medium: Int, low: Int, undefined: Int, informational: Int)
@@ -35,8 +36,9 @@ object ScanDecoder {
     repositoryName <- c.downField("repository-name").as[String]
     imageTags <- c.downField("image-tags").as[List[String]]
     imageDigest <- c.downField("image-digest").as[String]
-    findingSeverityCounts <- c.downField("finding-severity-counts").as[ScanFindingCounts]
-  } yield ScanDetail(repositoryName, imageTags, imageDigest, findingSeverityCounts)
+    scanStatus <- c.downField("scan-status").as[String]
+    findingSeverityCounts <- c.downField("finding-severity-counts").as[Option[ScanFindingCounts]]
+  } yield ScanDetail(repositoryName, imageTags, imageDigest, findingSeverityCounts, scanStatus)
 
   val decodeScanEvent: Decoder[IncomingEvent] = (c: HCursor) => for {
     detail <- c.downField("detail").as[ScanDetail]

--- a/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
+++ b/src/main/scala/uk/gov/nationalarchives/notifications/messages/EventMessages.scala
@@ -112,33 +112,43 @@ object EventMessages {
 
     override def context(event: ScanEvent): IO[ImageScanReport] = {
       val repoName = event.detail.repositoryName
-      val ecrClient = ecr(URI.create(ConfigFactory.load.getString("ecr.endpoint")))
-      val ecrUtils: ECRUtils = ECRUtils(ecrClient)
-      val findingsResponse = ecrUtils.imageScanFindings(repoName, event.detail.imageDigest)
+      if (event.detail.scanStatus != "COMPLETE") {
+        logger.info(s"ECR scan status is ${event.detail.scanStatus} for ${event.detail.repositoryName}, skipping ECR API call to get image scan findings")
+        IO(ImageScanReport(List()))
+      } else {
+        val ecrClient = ecr(URI.create(ConfigFactory.load.getString("ecr.endpoint")))
+        val ecrUtils: ECRUtils = ECRUtils(ecrClient)
+        val findingsResponse = ecrUtils.imageScanFindings(repoName, event.detail.imageDigest)
 
-      findingsResponse.map(response => {
-        val findings = response.imageScanFindings.findings.asScala.map(finding => {
-          Finding(finding.name, finding.severity)
-        }).toSeq
-        ImageScanReport(findings)
-      })
+        findingsResponse.map(response => {
+          val findings = response.imageScanFindings.findings.asScala.map(finding => {
+            Finding(finding.name, finding.severity)
+          }).toSeq
+          ImageScanReport(findings)
+        })
+      }
     }
 
     override def slack(event: ScanEvent, report: ImageScanReport): Option[SlackMessage] = {
       val detail = event.detail
       val filteredReport = filterReport(report)
-      if (shouldSendSlackNotification(detail, filteredReport.findings)) {
-        val headerBlock = slackBlock(s"*ECR image scan complete on image ${detail.repositoryName} ${detail.tags.mkString(",")}*")
-
-        val criticalBlock = slackBlock(s"${filteredReport.criticalCount} critical severity vulnerabilities")
-        val highBlock = slackBlock(s"${filteredReport.highCount} high severity vulnerabilities")
-        val mediumBlock = slackBlock(s"${filteredReport.mediumCount} medium severity vulnerabilities")
-        val lowBlock = slackBlock(s"${filteredReport.lowCount} low severity vulnerabilities")
-        val undefinedBlock = slackBlock(s"${filteredReport.undefinedCount} undefined severity vulnerabilities")
-        val documentationBlock = slackBlock(ecrScanDocumentationMessage)
-        SlackMessage(List(headerBlock, criticalBlock, highBlock, mediumBlock, lowBlock, undefinedBlock, documentationBlock)).some
+      if (detail.scanStatus != "COMPLETE") {
+        val headerBlock = slackBlock(s"*ECR image scan ${detail.scanStatus} on image ${detail.repositoryName} ${detail.tags.mkString(",")}*")
+        SlackMessage(List(headerBlock)).some
       } else {
-        Option.empty
+        if (shouldSendSlackNotification(detail, filteredReport.findings)) {
+          val headerBlock = slackBlock(s"*ECR image scan complete on image ${detail.repositoryName} ${detail.tags.mkString(",")}*")
+
+          val criticalBlock = slackBlock(s"${filteredReport.criticalCount} critical severity vulnerabilities")
+          val highBlock = slackBlock(s"${filteredReport.highCount} high severity vulnerabilities")
+          val mediumBlock = slackBlock(s"${filteredReport.mediumCount} medium severity vulnerabilities")
+          val lowBlock = slackBlock(s"${filteredReport.lowCount} low severity vulnerabilities")
+          val undefinedBlock = slackBlock(s"${filteredReport.undefinedCount} undefined severity vulnerabilities")
+          val documentationBlock = slackBlock(ecrScanDocumentationMessage)
+          SlackMessage(List(headerBlock, criticalBlock, highBlock, mediumBlock, lowBlock, undefinedBlock, documentationBlock)).some
+        } else {
+          Option.empty
+        }
       }
     }
 
@@ -517,7 +527,7 @@ object EventMessages {
     val govukNotifyApiKeyParameterName = "/keycloak/govuk_notify/api_key"
     val npmTokenParameterName          = "/npm_granular_token"
 
-    val tokenParameters = List(githubAccessTokenParameterName, govukNotifyApiKeyParameterName, npmTokenParameterName)
+    val tokenParameters: List[String] = List(githubAccessTokenParameterName, govukNotifyApiKeyParameterName, npmTokenParameterName)
 
     override def context(incomingEvent: ParameterStoreExpiryEvent): IO[Unit] = IO.unit
 

--- a/src/test/resources/ecr-findings/ecr-scan-failed.json
+++ b/src/test/resources/ecr-findings/ecr-scan-failed.json
@@ -1,0 +1,12 @@
+{
+  "registryId": "1234",
+  "repositoryName": "some-repo-name",
+  "imageId": {
+    "imageDigest": "sha256:0dd8216bcde6a8c286f797f3ea79faa6ee1dabcbd663470b0e54b2aec56285da",
+    "imageTag": "intg"
+  },
+  "imageScanStatus": {
+    "status": "FAILED",
+    "description": "The scan was completed successfully."
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.notifications
 
+import cats.implicits.catsSyntaxOptionId
 import com.github.tomakehurst.wiremock.client.WireMock._
-import org.scalatest.prop.TableFor8
 import uk.gov.nationalarchives.notifications.EcrScanIntegrationSpec.scanEventInputText
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.{ScanDetail, ScanEvent, ScanFindingCounts}
 
@@ -55,6 +55,12 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       stubContext = stubEcrApiResponse(noVulnerabilitiesEvent.detail.imageDigest, noFindings)
     ),
     Event(
+      description = "an ECR scan of an image which fails",
+      input = scanEventInputText(ecrScanFailedEvent),
+      expectedOutput = ExpectedOutput(),
+      stubContext = stubEcrApiResponse(ecrScanFailedEvent.detail.imageDigest, ecrScanFailed)
+    ),
+    Event(
       description = "an ECR scan of an image with a non-deployment tag",
       input = scanEventInputText(otherTagEvent),
       expectedOutput = ExpectedOutput(),
@@ -82,22 +88,23 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
     )
   )
   
-  private lazy val mixedSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd1", mixedCounts))
-  private lazy val lowSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd2", lowSeverityCounts))
-  private lazy val mediumSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd2", mediumSeverityCounts))
-  private lazy val informationalEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "1234", informationalCounts))
-  private lazy val undefinedSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "1234", undefinedSeverityCounts))
-  private lazy val noVulnerabilitiesEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd3", emptyCounts))
-  private lazy val otherTagEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("anothertag"), "abcd4", emptyCounts))
-  private lazy val intgTagEmptyEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("intg"), "abcd5", zeroCounts))
+  private lazy val mixedSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd1", mixedCounts, "COMPLETE"))
+  private lazy val lowSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd2", lowSeverityCounts, "COMPLETE"))
+  private lazy val mediumSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd2", mediumSeverityCounts, "COMPLETE"))
+  private lazy val informationalEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "1234", informationalCounts, "COMPLETE"))
+  private lazy val undefinedSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "1234", undefinedSeverityCounts, "COMPLETE"))
+  private lazy val noVulnerabilitiesEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd3", emptyCounts, "COMPLETE"))
+  private lazy val otherTagEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("anothertag"), "abcd4", emptyCounts, "COMPLETE"))
+  private lazy val intgTagEmptyEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("intg"), "abcd5", zeroCounts, "COMPLETE"))
+  private lazy val ecrScanFailedEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd6", None, "FAILED"))
 
-  private lazy val mixedCounts = ScanFindingCounts(10, 100, 1000, 10000, 10, 1)
-  private lazy val lowSeverityCounts = ScanFindingCounts(0, 0, 0, 10, 0, 0)
-  private lazy val mediumSeverityCounts = ScanFindingCounts(0, 0, 10, 0, 0, 0)
-  private lazy val informationalCounts = ScanFindingCounts(0, 0, 0, 0, 10, 0)
-  private lazy val undefinedSeverityCounts = ScanFindingCounts(0, 0, 0, 0, 10, 0)
-  private lazy val emptyCounts = ScanFindingCounts(0, 0, 0, 0, 0, 0)
-  private lazy val zeroCounts = ScanFindingCounts(0, 0, 0, 0, 0, 0)
+  private lazy val mixedCounts = ScanFindingCounts(10, 100, 1000, 10000, 10, 1).some
+  private lazy val lowSeverityCounts = ScanFindingCounts(0, 0, 0, 10, 0, 0).some
+  private lazy val mediumSeverityCounts = ScanFindingCounts(0, 0, 10, 0, 0, 0).some
+  private lazy val informationalCounts = ScanFindingCounts(0, 0, 0, 0, 10, 0).some
+  private lazy val undefinedSeverityCounts = ScanFindingCounts(0, 0, 0, 0, 10, 0).some
+  private lazy val emptyCounts = ScanFindingCounts(0, 0, 0, 0, 0, 0).some
+  private lazy val zeroCounts = ScanFindingCounts(0, 0, 0, 0, 0, 0).some
 
   private lazy val mixedSeverityFindings = Source.fromResource("ecr-findings/mixed-severity.json").getLines.mkString
   private lazy val mediumSeverityFindings = Source.fromResource("ecr-findings/medium-severity.json").getLines.mkString
@@ -105,6 +112,7 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
   private lazy val undefinedFindings = Source.fromResource("ecr-findings/undefined-severity.json").getLines.mkString
   private lazy val informationalFindings = Source.fromResource("ecr-findings/informational.json").getLines.mkString
   private lazy val noFindings = Source.fromResource("ecr-findings/no-findings.json").getLines.mkString
+  private lazy val ecrScanFailed = Source.fromResource("ecr-findings/ecr-scan-failed.json").getLines.mkString
   private lazy val findingsWithOnlyMutedVulnerability = Source.fromResource("ecr-findings/muted-vulnerability.json").getLines.mkString
   private lazy val findingsIncludingMutedVulnerability = Source.fromResource("ecr-findings/including-muted-vulnerability.json").getLines.mkString
 
@@ -171,11 +179,11 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
 
 object EcrScanIntegrationSpec {
   private def getCounts(scanEvent: ScanEvent): (Int, Int, Int, Int, Int) = {
-    val critical = scanEvent.detail.findingSeverityCounts.critical
-    val high = scanEvent.detail.findingSeverityCounts.high
-    val medium = scanEvent.detail.findingSeverityCounts.medium
-    val low = scanEvent.detail.findingSeverityCounts.low
-    val undefined = scanEvent.detail.findingSeverityCounts.undefined
+    val critical = scanEvent.detail.findingSeverityCounts.map(_.critical).getOrElse(0)
+    val high = scanEvent.detail.findingSeverityCounts.map(_.high).getOrElse(0)
+    val medium = scanEvent.detail.findingSeverityCounts.map(_.medium).getOrElse(0)
+    val low = scanEvent.detail.findingSeverityCounts.map(_.low).getOrElse(0)
+    val undefined = scanEvent.detail.findingSeverityCounts.map(_.undefined).getOrElse(0)
     (critical, high, medium, low, undefined)
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/EcrScanIntegrationSpec.scala
@@ -14,7 +14,7 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       description = "an ECR scan of 'latest' with a mix of severities",
       input = scanEventInputText(mixedSeverityEvent),
       expectedOutput = ExpectedOutput(
-        slackMessage = Some(SlackMessage(body = expectedSlackBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 4, 1)), webhookUrl = "/webhook-url"))
+        slackMessage = Some(SlackMessage(body = expectedSlackBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 4, 1).some), webhookUrl = "/webhook-url"))
       ),
       stubContext = stubEcrApiResponse(mixedSeverityEvent.detail.imageDigest, mixedSeverityFindings)
     ),
@@ -22,7 +22,7 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       description = "an ECR scan of 'latest' with only medium severity vulnerabilities",
       input = scanEventInputText(mediumSeverityEvent),
       expectedOutput = ExpectedOutput(
-        slackMessage = Some(SlackMessage(body = expectedSlackBody(mediumSeverityEvent, ExpectedFindings(0, 0, 1, 0, 0)), webhookUrl = "/webhook-url"))
+        slackMessage = Some(SlackMessage(body = expectedSlackBody(mediumSeverityEvent, ExpectedFindings(0, 0, 1, 0, 0).some), webhookUrl = "/webhook-url"))
       ),
       stubContext = stubEcrApiResponse(mediumSeverityEvent.detail.imageDigest, mediumSeverityFindings)
     ),
@@ -30,7 +30,7 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       description = "an ECR scan of 'latest' with only low severity vulnerabilities",
       input = scanEventInputText(lowSeverityEvent),
       expectedOutput = ExpectedOutput(
-        slackMessage = Some(SlackMessage(body = expectedSlackBody(lowSeverityEvent, ExpectedFindings(0, 0, 0, 1, 0)), webhookUrl = "/webhook-url"))
+        slackMessage = Some(SlackMessage(body = expectedSlackBody(lowSeverityEvent, ExpectedFindings(0, 0, 0, 1, 0).some), webhookUrl = "/webhook-url"))
       ),
       stubContext = stubEcrApiResponse(lowSeverityEvent.detail.imageDigest, lowSeverityFindings)
     ),
@@ -38,7 +38,7 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       description = "an ECR scan of 'latest' with only undefined severity vulnerabilities",
       input = scanEventInputText(undefinedSeverityEvent),
       expectedOutput = ExpectedOutput(
-        slackMessage = Some(SlackMessage(body = expectedSlackBody(undefinedSeverityEvent, ExpectedFindings(0, 0, 0, 0, 1)), webhookUrl = "/webhook-url"))
+        slackMessage = Some(SlackMessage(body = expectedSlackBody(undefinedSeverityEvent, ExpectedFindings(0, 0, 0, 0, 1).some), webhookUrl = "/webhook-url"))
       ),
       stubContext = stubEcrApiResponse(undefinedSeverityEvent.detail.imageDigest, undefinedFindings)
     ),
@@ -57,7 +57,9 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
     Event(
       description = "an ECR scan of an image which fails",
       input = scanEventInputText(ecrScanFailedEvent),
-      expectedOutput = ExpectedOutput(),
+      expectedOutput = ExpectedOutput(
+        slackMessage = Some(SlackMessage(body = expectedSlackBody(ecrScanFailedEvent, None), webhookUrl = "/webhook-url"))
+      ),
       stubContext = stubEcrApiResponse(ecrScanFailedEvent.detail.imageDigest, ecrScanFailed)
     ),
     Event(
@@ -82,12 +84,12 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
       description = "an ECR scan with a mix of muted and non-muted vulnerabilities",
       input = scanEventInputText(mixedSeverityEvent),
       expectedOutput = ExpectedOutput(
-        slackMessage = Some(SlackMessage(body = expectedSlackBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 3, 0)), webhookUrl = "/webhook-url"))
+        slackMessage = Some(SlackMessage(body = expectedSlackBody(mixedSeverityEvent, ExpectedFindings(1, 2, 24, 3, 0).some), webhookUrl = "/webhook-url"))
       ),
       stubContext = stubEcrApiResponse(mixedSeverityEvent.detail.imageDigest, findingsIncludingMutedVulnerability)
     )
   )
-  
+
   private lazy val mixedSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd1", mixedCounts, "COMPLETE"))
   private lazy val lowSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd2", lowSeverityCounts, "COMPLETE"))
   private lazy val mediumSeverityEvent: ScanEvent = ScanEvent(ScanDetail("repo-name", List("latest"), "abcd2", mediumSeverityCounts, "COMPLETE"))
@@ -126,54 +128,68 @@ class EcrScanIntegrationSpec extends LambdaIntegrationSpec with MockEcrApi {
     )
   }
 
-  private def expectedSlackBody(scanEvent: ScanEvent, expectedFindings: ExpectedFindings): String = {
-    s"""
-       |{
-       |  "blocks" : [ {
-       |    "type" : "section",
-       |    "text" : {
-       |      "type" : "mrkdwn",
-       |      "text" : "*ECR image scan complete on image ${scanEvent.detail.repositoryName} ${scanEvent.detail.tags.mkString(",")}*"
-       |    }
-       |  }, {
-       |    "type" : "section",
-       |    "text" : {
-       |      "type" : "mrkdwn",
-       |      "text" : "${expectedFindings.critical} critical severity vulnerabilities"
-       |    }
-       |  }, {
-       |    "type" : "section",
-       |    "text" : {
-       |      "type" : "mrkdwn",
-       |      "text" : "${expectedFindings.high} high severity vulnerabilities"
-       |    }
-       |  }, {
-       |    "type" : "section",
-       |    "text" : {
-       |      "type" : "mrkdwn",
-       |      "text" : "${expectedFindings.medium} medium severity vulnerabilities"
-       |    }
-       |  }, {
-       |    "type" : "section",
-       |    "text" : {
-       |      "type" : "mrkdwn",
-       |      "text" : "${expectedFindings.low} low severity vulnerabilities"
-       |    }
-       |  }, {
-       |    "type" : "section",
-       |    "text" : {
-       |      "type" : "mrkdwn",
-       |      "text" : "${expectedFindings.undefined} undefined severity vulnerabilities"
-       |    }
-       |  }, {
-       |    "type" : "section",
-       |    "text" : {
-       |      "type" : "mrkdwn",
-       |      "text" : "See the TDR developer manual for guidance on fixing these vulnerabilities: https://github.com/nationalarchives/tdr-dev-documentation/blob/master/manual/alerts/ecr-scans.md"
-       |    }
-       |  } ]
-       |}
-       |""".stripMargin
+  private def expectedSlackBody(scanEvent: ScanEvent, expectedFindings: Option[ExpectedFindings] = None): String = {
+    if (scanEvent.detail.scanStatus == "FAILED") {
+      s"""
+         |{
+         |  "blocks" : [ {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : "*ECR image scan FAILED on image ${scanEvent.detail.repositoryName} ${scanEvent.detail.tags.mkString(",")}*"
+         |    }
+         |  }]
+         |}
+         |""".stripMargin
+    } else {
+      s"""
+         |{
+         |  "blocks" : [ {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : "*ECR image scan complete on image ${scanEvent.detail.repositoryName} ${scanEvent.detail.tags.mkString(",")}*"
+         |    }
+         |  }, {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : "${expectedFindings.get.critical} critical severity vulnerabilities"
+         |    }
+         |  }, {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : "${expectedFindings.get.high} high severity vulnerabilities"
+         |    }
+         |  }, {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : "${expectedFindings.get.medium} medium severity vulnerabilities"
+         |    }
+         |  }, {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : "${expectedFindings.get.low} low severity vulnerabilities"
+         |    }
+         |  }, {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : "${expectedFindings.get.undefined} undefined severity vulnerabilities"
+         |    }
+         |  }, {
+         |    "type" : "section",
+         |    "text" : {
+         |      "type" : "mrkdwn",
+         |      "text" : "See the TDR developer manual for guidance on fixing these vulnerabilities: https://github.com/nationalarchives/tdr-dev-documentation/blob/master/manual/alerts/ecr-scans.md"
+         |    }
+         |  } ]
+         |}
+         |""".stripMargin
+    }
   }
 }
 
@@ -189,22 +205,35 @@ object EcrScanIntegrationSpec {
 
   def scanEventInputText(scanEvent: ScanEvent): String = {
     val (critical, high, medium, low, undefined) = getCounts(scanEvent)
-    s"""
-       |{
-       |  "detail": {
-       |    "scan-status": "COMPLETE",
-       |    "repository-name": "${scanEvent.detail.repositoryName}",
-       |    "image-tags": ["${scanEvent.detail.tags.mkString("\",\"")}"],
-       |    "image-digest": "${scanEvent.detail.imageDigest}",
-       |    "finding-severity-counts": {
-       |      "CRITICAL": $critical,
-       |      "HIGH": $high,
-       |      "MEDIUM": $medium,
-       |      "LOW": $low,
-       |      "UNDEFINED": $undefined
-       |    }
-       |  }
-       |}
-       |""".stripMargin
+    if (scanEvent.detail.findingSeverityCounts.isDefined) {
+      s"""
+         |{
+         |  "detail": {
+         |    "scan-status": "${scanEvent.detail.scanStatus}",
+         |    "repository-name": "${scanEvent.detail.repositoryName}",
+         |    "image-tags": ["${scanEvent.detail.tags.mkString("\",\"")}"],
+         |    "image-digest": "${scanEvent.detail.imageDigest}",
+         |    "finding-severity-counts": {
+         |      "CRITICAL": $critical,
+         |      "HIGH": $high,
+         |      "MEDIUM": $medium,
+         |      "LOW": $low,
+         |      "UNDEFINED": $undefined
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+    } else {
+      s"""
+         |{
+         |  "detail": {
+         |    "scan-status": "${scanEvent.detail.scanStatus}",
+         |    "repository-name": "${scanEvent.detail.repositoryName}",
+         |    "image-tags": ["${scanEvent.detail.tags.mkString("\",\"")}"],
+         |    "image-digest": "${scanEvent.detail.imageDigest}"
+         |  }
+         |}
+         |""".stripMargin
+    }
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/notifications/LambdaErrorSpec.scala
@@ -1,5 +1,6 @@
 package uk.gov.nationalarchives.notifications
 
+import cats.implicits.catsSyntaxOptionId
 import com.github.tomakehurst.wiremock.client.WireMock.{ok, post, urlEqualTo}
 import uk.gov.nationalarchives.notifications.EcrScanIntegrationSpec.scanEventInputText
 import uk.gov.nationalarchives.notifications.decoders.ScanDecoder.{ScanDetail, ScanEvent, ScanFindingCounts}
@@ -14,7 +15,7 @@ class LambdaErrorSpec extends LambdaSpecUtils with MockEcrApi {
     ecrApiEndpoint.stubFor(post(urlEqualTo("/"))
       .willReturn(ok(highSeverityEcrApiResponse)))
 
-    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000, 1, 10)))
+    val scanEvent = ScanEvent(ScanDetail("", List("latest"), "some-sha256-digest", ScanFindingCounts(10, 100, 1000, 10000, 1, 10).some, "COMPLETE"))
     val stream = new java.io.ByteArrayInputStream(scanEventInputText(scanEvent).getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
     wiremockSlackServer.resetAll()
     val exception = intercept[Exception] {


### PR DESCRIPTION
When an ECR scan for a repo fails then it doesn't return "finding-severity-counts".